### PR TITLE
feat: password reset via Gmail SMTP, stronger registration validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,28 @@ Environment configuration is split so that **development** uses your local backe
 
 Note: `backend/.env` is in `.gitignore`. Create it locally; it will not be committed.
 
+### Email / Password Reset
+
+Password reset emails are sent via Django's SMTP backend. Gmail is the supported provider for development and production.
+
+Uncomment and fill in these variables in `backend/.env`:
+
+```dotenv
+EMAIL_BACKEND=accounts.smtp_backend.CertifiSMTPBackend
+EMAIL_HOST=smtp.gmail.com
+EMAIL_PORT=587
+EMAIL_USE_TLS=True
+EMAIL_HOST_USER=your-address@gmail.com
+EMAIL_HOST_PASSWORD=xxxx xxxx xxxx xxxx   # 16-char Gmail App Password
+DEFAULT_FROM_EMAIL=your-address@gmail.com
+```
+
+**Gmail App Password**: your normal Google account password will not work. Generate a 16-character App Password at <https://myaccount.google.com/apppasswords> (requires 2-Step Verification enabled on the account).
+
+**`CertifiSMTPBackend`**: a thin wrapper around Django's built-in SMTP backend (`accounts/smtp_backend.py`) that uses `certifi`'s CA bundle for SSL verification. This is required on macOS where Python's default SSL context cannot locate the system certificate store. It is safe on Linux/AWS (certifi's bundle is equally valid there).
+
+If `EMAIL_BACKEND` is not set, Django falls back to `console.EmailBackend` and prints emails to stdout — useful for local dev without a real mailbox. In DEBUG mode the reset link is also always logged to the Django console regardless of email delivery.
+
 ### Frontend Setup
 
 No file copying is required.
@@ -208,7 +230,15 @@ eb setenv \
   ALLOWED_HOSTS=<backend-cname>,localhost,127.0.0.1 \
   DB_PATH=/var/app/db/db.sqlite3 \
   CORS_ALLOWED_ORIGINS=http://<frontend-cname> \
-  CSRF_TRUSTED_ORIGINS=http://<frontend-cname>
+  CSRF_TRUSTED_ORIGINS=http://<frontend-cname> \
+  EMAIL_BACKEND=accounts.smtp_backend.CertifiSMTPBackend \
+  EMAIL_HOST=smtp.gmail.com \
+  EMAIL_PORT=587 \
+  EMAIL_USE_TLS=True \
+  EMAIL_HOST_USER=<your-gmail-address> \
+  EMAIL_HOST_PASSWORD=<your-16-char-app-password> \
+  DEFAULT_FROM_EMAIL=<your-gmail-address> \
+  FRONTEND_BASE_URL=http://<frontend-cname>
 
 # Deploy
 eb deploy --timeout 5
@@ -314,11 +344,13 @@ Use the module path **`tests.test_auth_integration`** (not `backend.tests...`). 
 
 Auth is tested against the **JSON API** under `/api/auth/` in `backend/tests/test_auth_integration.py`:
 
-1. **Registration** – success (hashed password, auto-login), duplicate email, invalid email, method not allowed
+1. **Registration** – success (hashed password, auto-login), duplicate email, invalid email, method not allowed; password must meet Django validators (min 8 chars, not common, not all-numeric)
 2. **Login** – success (session + current user), invalid credentials → 401, method not allowed
 3. **Logout** – POST clears session; unauthenticated current-user returns 401
 4. **Current user** – authenticated returns profile (id, email, name); unauthenticated → 401
-5. **Password reset request** – valid email → 200 + neutral message; invalid/missing email → 400
-6. **Rate limiting** – 10+ failed logins → 429; successful login resets counter
+5. **Password reset request** – valid email → 200 + neutral message (prevents user enumeration); invalid/missing email → 400; email sender is mocked in tests
+6. **Password reset token validation** – valid uid/token → 200 `{valid: true}`; invalid or expired token → 400 `{valid: false}`
+7. **Password reset confirm** – valid token + strong password → 200, password updated; weak password rejected → 400; invalid token → 400
+8. **Rate limiting** – 10+ failed logins → 429; successful login resets counter
 
 See **`docs/TEST_RESULTS.md`** for a full test summary and how to run a single test.

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -15,10 +15,11 @@ ALLOWED_HOSTS=localhost,127.0.0.1
 # Optional: database path (default: backend/db.sqlite3)
 # DB_PATH=db.sqlite3
 
-# Optional: email (default: console backend)
-# EMAIL_BACKEND=django.core.mail.backends.smtp.EmailBackend
-# EMAIL_HOST=smtp.sendgrid.net
-# EMAIL_HOST_USER=apikey
-# EMAIL_HOST_PASSWORD=your-sendgrid-api-key
+# email (default: console backend)
+# EMAIL_BACKEND=accounts.smtp_backend.CertifiSMTPBackend
+# EMAIL_HOST=smtp.gmail.com
 # EMAIL_PORT=587
-# DEFAULT_FROM_EMAIL=no-reply@example.com
+# EMAIL_USE_TLS=True
+# EMAIL_HOST_USER=<your-email>@gmail.com
+# EMAIL_HOST_PASSWORD=<your-gmail-app-password>
+# DEFAULT_FROM_EMAIL=<your-email>@gmail.com

--- a/backend/accounts/api_urls.py
+++ b/backend/accounts/api_urls.py
@@ -8,4 +8,6 @@ urlpatterns = [
     path('me/', views.api_me, name='api_me'),
     path('preferences/', views.api_preferences_update, name='api_preferences_update'),
     path('request-password-reset/', views.api_request_password_reset, name='api_request_password_reset'),
+    path('validate-password-reset-token/', views.api_validate_password_reset_token, name='api_validate_password_reset_token'),
+    path('confirm-password-reset/', views.api_confirm_password_reset, name='api_confirm_password_reset'),
 ]

--- a/backend/accounts/email_service.py
+++ b/backend/accounts/email_service.py
@@ -1,0 +1,57 @@
+import logging
+import smtplib
+
+from django.conf import settings
+from django.core.mail import send_mail
+
+logger = logging.getLogger(__name__)
+
+
+class EmailSendError(Exception):
+    """Raised when an email fails to send via SMTP."""
+
+    pass
+
+
+# Keep the old name around so any existing imports/catches still work.
+ResendEmailError = EmailSendError
+
+
+def send_password_reset_email(to_email: str, reset_link: str) -> None:
+    """Send a password-reset email using Django's configured SMTP backend.
+
+    Relies on EMAIL_BACKEND, EMAIL_HOST, EMAIL_HOST_USER, EMAIL_HOST_PASSWORD,
+    EMAIL_PORT, EMAIL_USE_TLS, and DEFAULT_FROM_EMAIL in Django settings.
+    """
+    from_email = getattr(settings, "DEFAULT_FROM_EMAIL", "no-reply@example.com")
+    subject = "Reset your Meal Swipe password"
+    message = (
+        "You requested a password reset for your Meal Swipe account.\n\n"
+        f"Use the link below to set a new password:\n{reset_link}\n\n"
+        "This link expires in 1 hour. If you did not request this reset, "
+        "you can safely ignore this email."
+    )
+
+    try:
+        send_mail(
+            subject=subject,
+            message=message,
+            from_email=from_email,
+            recipient_list=[to_email],
+            fail_silently=False,
+        )
+        logger.info("Password reset email sent to %s", to_email)
+    except smtplib.SMTPAuthenticationError as exc:
+        logger.error(
+            "SMTP authentication failed. Check EMAIL_HOST_USER and "
+            "EMAIL_HOST_PASSWORD in your .env (Gmail requires a 16-char App Password). "
+            "Error: %s",
+            exc,
+        )
+        raise EmailSendError("SMTP authentication failed") from exc
+    except smtplib.SMTPException as exc:
+        logger.error("SMTP error while sending password reset email: %s", exc)
+        raise EmailSendError(f"Failed to send email via SMTP: {exc}") from exc
+    except Exception as exc:
+        logger.error("Unexpected error sending password reset email: %s", exc)
+        raise EmailSendError(f"Failed to send email: {exc}") from exc

--- a/backend/accounts/forms.py
+++ b/backend/accounts/forms.py
@@ -1,27 +1,36 @@
 from django import forms
 from django.contrib.auth.forms import ReadOnlyPasswordHashField
+from django.contrib.auth.password_validation import validate_password
+from django.core.exceptions import ValidationError
 
 from .models import User
 
 
 class UserCreationForm(forms.ModelForm):
-    password1 = forms.CharField(label='Password', widget=forms.PasswordInput)
-    password2 = forms.CharField(label='Password confirmation', widget=forms.PasswordInput)
+    password1 = forms.CharField(label="Password", widget=forms.PasswordInput)
+    password2 = forms.CharField(
+        label="Password confirmation", widget=forms.PasswordInput
+    )
 
     class Meta:
         model = User
-        fields = ('email', 'first_name', 'last_name')
+        fields = ("email", "first_name", "last_name")
 
     def clean_password2(self):
-        p1 = self.cleaned_data.get('password1')
-        p2 = self.cleaned_data.get('password2')
+        p1 = self.cleaned_data.get("password1")
+        p2 = self.cleaned_data.get("password2")
         if p1 and p2 and p1 != p2:
             raise forms.ValidationError("Passwords don't match")
+        if p1:
+            try:
+                validate_password(p1)
+            except ValidationError as exc:
+                raise forms.ValidationError(exc.messages) from exc
         return p2
 
     def save(self, commit=True):
         user = super().save(commit=False)
-        user.set_password(self.cleaned_data['password1'])
+        user.set_password(self.cleaned_data["password1"])
         if commit:
             user.save()
         return user
@@ -32,7 +41,14 @@ class UserChangeForm(forms.ModelForm):
 
     class Meta:
         model = User
-        fields = ('email', 'password', 'first_name', 'last_name', 'is_active', 'is_staff')
+        fields = (
+            "email",
+            "password",
+            "first_name",
+            "last_name",
+            "is_active",
+            "is_staff",
+        )
 
     def clean_password(self):
-        return self.initial['password']
+        return self.initial["password"]

--- a/backend/accounts/smtp_backend.py
+++ b/backend/accounts/smtp_backend.py
@@ -1,0 +1,40 @@
+"""Custom SMTP email backend that uses certifi for SSL certificate verification.
+
+macOS Python installations often lack access to the system certificate store,
+causing ``[SSL: CERTIFICATE_VERIFY_FAILED]`` when Django's default SMTP backend
+tries to connect to Gmail (or any TLS-enabled host).  This backend overrides
+the SSL context so that ``certifi``'s up-to-date CA bundle is always used.
+
+Usage – set in ``.env``::
+
+    EMAIL_BACKEND=accounts.smtp_backend.CertifiSMTPBackend
+"""
+
+import ssl
+
+from django.core.mail.backends.smtp import EmailBackend as DjangoSMTPBackend
+
+
+class CertifiSMTPBackend(DjangoSMTPBackend):
+    """SMTP backend that builds an SSL context with certifi CA certificates."""
+
+    @property
+    def ssl_context(self):
+        ctx = self._ssl_context
+        if ctx is None:
+            try:
+                import certifi
+
+                ctx = ssl.create_default_context(cafile=certifi.where())
+            except ImportError:
+                ctx = ssl.create_default_context()
+            self._ssl_context = ctx
+        return ctx
+
+    @ssl_context.setter
+    def ssl_context(self, value):
+        self._ssl_context = value
+
+    def __init__(self, *args, **kwargs):
+        self._ssl_context = None
+        super().__init__(*args, **kwargs)

--- a/backend/accounts/views.py
+++ b/backend/accounts/views.py
@@ -1,15 +1,23 @@
 import json
 import logging
+from urllib.parse import urljoin
 from django.shortcuts import render, redirect
 from django.contrib.auth import login, logout, authenticate
+from django.contrib.auth import get_user_model
+from django.contrib.auth.password_validation import validate_password
+from django.contrib.auth.tokens import default_token_generator
 from django.views import View
 from django.core.validators import validate_email
 from django.core.exceptions import ValidationError
+from django.conf import settings
 from django.http import JsonResponse
 from django.core.cache import cache
 from django.views.decorators.csrf import ensure_csrf_cookie, csrf_exempt
+from django.utils.http import urlsafe_base64_decode, urlsafe_base64_encode
+from django.utils.encoding import force_bytes
 
 from .forms import UserCreationForm
+from .email_service import send_password_reset_email
 from .models import (
     SANITATION_GRADE_CHOICES,
     UserPreference,
@@ -22,6 +30,29 @@ from django.utils.text import slugify
 logger = logging.getLogger(__name__)
 
 VALID_SANITATION_GRADES = {choice[0] for choice in SANITATION_GRADE_CHOICES}
+User = get_user_model()
+
+
+def _build_frontend_reset_link(uid: str, token: str) -> str:
+    base_url = settings.FRONTEND_BASE_URL.rstrip("/") + "/"
+    return urljoin(base_url, f"reset-password/{uid}/{token}")
+
+
+def _get_user_from_uid(uidb64: str):
+    try:
+        uid = urlsafe_base64_decode(uidb64).decode()
+        return User.objects.filter(pk=uid).first()
+    except Exception:
+        return None
+
+
+def _is_valid_password_reset_token(uidb64: str, token: str):
+    user = _get_user_from_uid(uidb64)
+    if not user:
+        return None
+    if not default_token_generator.check_token(user, token):
+        return None
+    return user
 
 
 def _get_preferences_dict(user):
@@ -246,7 +277,7 @@ def api_request_password_reset(request):
     if request.method == "POST":
         try:
             data = json.loads(request.body)
-            email = data.get("email", "")
+            email = (data.get("email", "") or "").strip()
 
             if not email:
                 return JsonResponse(
@@ -256,8 +287,35 @@ def api_request_password_reset(request):
             # Server-side email validation
             validate_email(email)
 
-            # NOTE: We do not check if the user exists or send the email yet.
-            # Returning a neutral response prevents user enumeration attacks.
+            user = User.objects.filter(email__iexact=email).first()
+            if user and user.is_active:
+                uid = urlsafe_base64_encode(force_bytes(user.pk))
+                token = default_token_generator.make_token(user)
+                reset_link = _build_frontend_reset_link(uid, token)
+
+                # In development, always print the link so it can be used
+                # even when email delivery is restricted (e.g. no verified domain).
+                if settings.DEBUG:
+                    logger.info(
+                        "\n"
+                        "=" * 60 + "\n"
+                        "PASSWORD RESET LINK (dev – no email required):\n"
+                        "%s\n"
+                        "=" * 60,
+                        reset_link,
+                    )
+
+                try:
+                    send_password_reset_email(user.email, reset_link)
+                except Exception as send_error:
+                    logger.error(
+                        "Failed to send password reset email for user_id=%s: %s",
+                        user.id,
+                        send_error,
+                        exc_info=True,
+                    )
+
+            # Return a neutral response to prevent user enumeration.
             return JsonResponse(
                 {
                     "success": True,
@@ -280,3 +338,89 @@ def api_request_password_reset(request):
             )
 
     return JsonResponse({"error": "Method not allowed"}, status=405)
+
+
+@csrf_exempt
+def api_validate_password_reset_token(request):
+    if request.method != "POST":
+        return JsonResponse({"error": "Method not allowed"}, status=405)
+
+    try:
+        data = json.loads(request.body)
+    except (json.JSONDecodeError, TypeError):
+        return JsonResponse(
+            {"success": False, "error": "Invalid JSON body"}, status=400
+        )
+
+    uid = (data.get("uid", "") or "").strip()
+    token = (data.get("token", "") or "").strip()
+    if not uid or not token:
+        return JsonResponse(
+            {
+                "success": False,
+                "valid": False,
+                "error": "Invalid or expired reset link",
+            },
+            status=400,
+        )
+
+    user = _is_valid_password_reset_token(uid, token)
+    if not user:
+        return JsonResponse(
+            {
+                "success": False,
+                "valid": False,
+                "error": "Invalid or expired reset link",
+            },
+            status=400,
+        )
+
+    return JsonResponse({"success": True, "valid": True})
+
+
+@csrf_exempt
+def api_confirm_password_reset(request):
+    if request.method != "POST":
+        return JsonResponse({"error": "Method not allowed"}, status=405)
+
+    try:
+        data = json.loads(request.body)
+    except (json.JSONDecodeError, TypeError):
+        return JsonResponse(
+            {"success": False, "error": "Invalid JSON body"}, status=400
+        )
+
+    uid = (data.get("uid", "") or "").strip()
+    token = (data.get("token", "") or "").strip()
+    new_password = data.get("new_password")
+
+    if not uid or not token or not new_password:
+        return JsonResponse(
+            {"success": False, "error": "uid, token, and new_password are required"},
+            status=400,
+        )
+
+    user = _is_valid_password_reset_token(uid, token)
+    if not user:
+        return JsonResponse(
+            {"success": False, "error": "Invalid or expired reset link"},
+            status=400,
+        )
+
+    try:
+        validate_password(new_password, user=user)
+    except ValidationError as validation_error:
+        return JsonResponse(
+            {"success": False, "error": " ".join(validation_error.messages)},
+            status=400,
+        )
+
+    user.set_password(new_password)
+    user.save(update_fields=["password"])
+
+    return JsonResponse(
+        {
+            "success": True,
+            "message": "Your password has been reset successfully.",
+        }
+    )

--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -12,16 +12,33 @@ https://docs.djangoproject.com/en/4.2/ref/settings/
 
 from pathlib import Path
 import os
+from urllib.parse import urlparse
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent
 
+
 # Load environment variables from backend/.env (optional; does not override existing env)
+def _load_env_file(env_file: Path):
+    if not env_file.exists():
+        return
+    for line in env_file.read_text().splitlines():
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#") or "=" not in stripped:
+            continue
+        key, value = stripped.split("=", 1)
+        key = key.strip()
+        value = value.strip().strip('"').strip("'")
+        if key and key not in os.environ:
+            os.environ[key] = value
+
+
 try:
     import dotenv
+
     dotenv.load_dotenv(BASE_DIR / ".env")
 except ImportError:
-    pass
+    _load_env_file(BASE_DIR / ".env")
 
 # Quick-start development settings - unsuitable for production
 # See https://docs.djangoproject.com/en/4.2/howto/deployment/checklist/
@@ -178,6 +195,10 @@ EMAIL_HOST_PASSWORD = os.environ.get("EMAIL_HOST_PASSWORD", "")
 EMAIL_USE_TLS = os.environ.get("EMAIL_USE_TLS", "True") == "True"
 DEFAULT_FROM_EMAIL = os.environ.get("DEFAULT_FROM_EMAIL", "no-reply@example.com")
 
+# Password reset settings
+PASSWORD_RESET_TIMEOUT = int(os.environ.get("PASSWORD_RESET_TIMEOUT", "3600"))
+FRONTEND_BASE_URL = os.environ.get("FRONTEND_BASE_URL", "http://localhost:5173")
+
 # CORS configuration
 _cors_origins_env = os.getenv("CORS_ALLOWED_ORIGINS", "")
 CORS_ALLOWED_ORIGINS = [o.strip() for o in _cors_origins_env.split(",") if o.strip()]
@@ -188,6 +209,21 @@ if not CORS_ALLOWED_ORIGINS:
         "http://localhost:5175",
         "http://127.0.0.1:5173",
     ]
+
+_frontend_origin = ""
+try:
+    _parsed_frontend = urlparse(FRONTEND_BASE_URL)
+    if _parsed_frontend.scheme and _parsed_frontend.netloc:
+        _frontend_origin = f"{_parsed_frontend.scheme}://{_parsed_frontend.netloc}"
+except Exception:
+    _frontend_origin = ""
+
+if _frontend_origin:
+    if _frontend_origin not in CORS_ALLOWED_ORIGINS:
+        CORS_ALLOWED_ORIGINS.append(_frontend_origin)
+    if _frontend_origin not in CSRF_TRUSTED_ORIGINS:
+        CSRF_TRUSTED_ORIGINS.append(_frontend_origin)
+
 CORS_ALLOW_CREDENTIALS = True
 
 # Redirects after login/logout

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -2,3 +2,4 @@ Django==4.2.28
 django-cors-headers==4.7.0
 gunicorn==22.0.0
 python-dotenv==1.0.1
+certifi==2026.2.25

--- a/backend/tests/test_auth_integration.py
+++ b/backend/tests/test_auth_integration.py
@@ -5,9 +5,14 @@ These tests target the JSON API endpoints under /api/auth/ (config.urls).
 """
 
 import json
+from datetime import datetime, timedelta
+from unittest.mock import patch
 from django.contrib.auth import get_user_model
+from django.contrib.auth.tokens import default_token_generator
+from django.utils.encoding import force_bytes
+from django.utils.http import urlsafe_base64_encode
 from django.urls import reverse
-from django.test import TestCase
+from django.test import TestCase, override_settings
 from django.core.cache import cache
 
 User = get_user_model()
@@ -39,8 +44,12 @@ def api_login_payload(email, password):
 
 class AuthIntegrationTests(TestCase):
     def setUp(self):
-        self.user = User.objects.create_user(email="reg@example.com", password="pass123")
-        self.staff = User.objects.create_user(email="staff@example.com", password="pass123")
+        self.user = User.objects.create_user(
+            email="reg@example.com", password="pass123"
+        )
+        self.staff = User.objects.create_user(
+            email="staff@example.com", password="pass123"
+        )
         self.staff.is_staff = True
         self.staff.save()
 
@@ -51,6 +60,8 @@ class AuthIntegrationTests(TestCase):
         self.current_user_url = reverse("api_me")
         self.preferences_url = reverse("api_preferences_update")
         self.password_reset_request_url = reverse("api_request_password_reset")
+        self.password_reset_validate_url = reverse("api_validate_password_reset_token")
+        self.password_reset_confirm_url = reverse("api_confirm_password_reset")
 
     # -------------------------------------------------------------------------
     # Registration
@@ -101,8 +112,12 @@ class AuthIntegrationTests(TestCase):
         body = resp.json()
         self.assertTrue(body.get("success"), body)
         self.assertIn("preferences", body["user"])
-        self.assertEqual(body["user"]["preferences"]["dietary"], ["Vegetarian", "Vegan"])
-        self.assertEqual(body["user"]["preferences"]["cuisines"], ["Italian", "Japanese"])
+        self.assertEqual(
+            body["user"]["preferences"]["dietary"], ["Vegetarian", "Vegan"]
+        )
+        self.assertEqual(
+            body["user"]["preferences"]["cuisines"], ["Italian", "Japanese"]
+        )
         self.assertEqual(body["user"]["preferences"]["foodTypes"], ["Pizza", "Salads"])
         self.assertEqual(body["user"]["preferences"]["minimum_sanitation_grade"], "A")
 
@@ -117,7 +132,7 @@ class AuthIntegrationTests(TestCase):
         """Duplicate email returns 400 with email field error (registration exposes this for UX).
         Contrast: password reset uses a neutral message to avoid account enumeration."""
         User.objects.create_user(email="dup@example.com", password="x")
-        data = api_register_payload("dup@example.com", "Aaa123!")
+        data = api_register_payload("dup@example.com", "Aaa1234!!")
         resp = self.client.post(
             self.register_url,
             data=json.dumps(data),
@@ -299,6 +314,136 @@ class AuthIntegrationTests(TestCase):
         resp = self.client.get(self.password_reset_request_url)
         self.assertEqual(resp.status_code, 405)
 
+    @patch("accounts.views.send_password_reset_email")
+    def test_password_reset_request_existing_user_sends_email(self, mock_send_email):
+        """Requesting reset for an existing user calls email sender with a reset link."""
+        User.objects.create_user(email="resetme@example.com", password="StrongPass!1")
+
+        resp = self.client.post(
+            self.password_reset_request_url,
+            data=json.dumps({"email": "resetme@example.com"}),
+            content_type="application/json",
+        )
+        self.assertEqual(resp.status_code, 200)
+        mock_send_email.assert_called_once()
+        to_email, reset_link = mock_send_email.call_args[0]
+        self.assertEqual(to_email, "resetme@example.com")
+        self.assertIn("/reset-password/", reset_link)
+
+    def test_password_reset_validate_token_success(self):
+        """Valid uid/token pair returns valid=true."""
+        user = User.objects.create_user(
+            email="tokenok@example.com", password="StrongPass!1"
+        )
+        uid = urlsafe_base64_encode(force_bytes(user.pk))
+        token = default_token_generator.make_token(user)
+
+        resp = self.client.post(
+            self.password_reset_validate_url,
+            data=json.dumps({"uid": uid, "token": token}),
+            content_type="application/json",
+        )
+        self.assertEqual(resp.status_code, 200)
+        body = resp.json()
+        self.assertTrue(body.get("success"))
+        self.assertTrue(body.get("valid"))
+
+    def test_password_reset_validate_token_invalid(self):
+        """Invalid token returns 400 with valid=false."""
+        user = User.objects.create_user(
+            email="tokenbad@example.com", password="StrongPass!1"
+        )
+        uid = urlsafe_base64_encode(force_bytes(user.pk))
+
+        resp = self.client.post(
+            self.password_reset_validate_url,
+            data=json.dumps({"uid": uid, "token": "invalid-token"}),
+            content_type="application/json",
+        )
+        self.assertEqual(resp.status_code, 400)
+        body = resp.json()
+        self.assertFalse(body.get("success", True))
+        self.assertFalse(body.get("valid", True))
+
+    def test_password_reset_confirm_success_updates_password(self):
+        """Confirm endpoint with valid token sets new password."""
+        user = User.objects.create_user(
+            email="confirmok@example.com", password="OldPass!123"
+        )
+        uid = urlsafe_base64_encode(force_bytes(user.pk))
+        token = default_token_generator.make_token(user)
+
+        resp = self.client.post(
+            self.password_reset_confirm_url,
+            data=json.dumps(
+                {
+                    "uid": uid,
+                    "token": token,
+                    "new_password": "NewStrongPass!456",
+                }
+            ),
+            content_type="application/json",
+        )
+        self.assertEqual(resp.status_code, 200)
+        body = resp.json()
+        self.assertTrue(body.get("success"), body)
+
+        user.refresh_from_db()
+        self.assertTrue(user.check_password("NewStrongPass!456"))
+        self.assertFalse(user.check_password("OldPass!123"))
+
+    def test_password_reset_confirm_invalid_password_rejected(self):
+        """Confirm endpoint rejects passwords that fail Django validators."""
+        user = User.objects.create_user(
+            email="confirmbad@example.com", password="OldPass!123"
+        )
+        uid = urlsafe_base64_encode(force_bytes(user.pk))
+        token = default_token_generator.make_token(user)
+
+        resp = self.client.post(
+            self.password_reset_confirm_url,
+            data=json.dumps(
+                {
+                    "uid": uid,
+                    "token": token,
+                    "new_password": "123",
+                }
+            ),
+            content_type="application/json",
+        )
+        self.assertEqual(resp.status_code, 400)
+        body = resp.json()
+        self.assertFalse(body.get("success", True))
+        self.assertIn("error", body)
+
+    @override_settings(PASSWORD_RESET_TIMEOUT=3600)
+    def test_password_reset_validate_token_expired(self):
+        """Token older than timeout is rejected as expired."""
+        user = User.objects.create_user(
+            email="expired@example.com", password="StrongPass!1"
+        )
+        uid = urlsafe_base64_encode(force_bytes(user.pk))
+        issue_time = datetime(2026, 3, 8, 10, 0, 0)
+
+        with patch.object(default_token_generator, "_now", return_value=issue_time):
+            token = default_token_generator.make_token(user)
+
+        with patch.object(
+            default_token_generator,
+            "_now",
+            return_value=issue_time + timedelta(hours=2),
+        ):
+            resp = self.client.post(
+                self.password_reset_validate_url,
+                data=json.dumps({"uid": uid, "token": token}),
+                content_type="application/json",
+            )
+
+        self.assertEqual(resp.status_code, 400)
+        body = resp.json()
+        self.assertFalse(body.get("success", True))
+        self.assertFalse(body.get("valid", True))
+
     # -------------------------------------------------------------------------
     # Preferences update (PATCH)
     # -------------------------------------------------------------------------
@@ -335,7 +480,12 @@ class AuthIntegrationTests(TestCase):
 
     def test_preferences_update_unauthenticated_returns_401(self):
         """PATCH preferences when not logged in returns 401."""
-        payload = {"dietary": [], "cuisines": [], "foodTypes": [], "minimum_sanitation_grade": "C"}
+        payload = {
+            "dietary": [],
+            "cuisines": [],
+            "foodTypes": [],
+            "minimum_sanitation_grade": "C",
+        }
         resp = self.client.patch(
             self.preferences_url,
             data=json.dumps(payload),
@@ -350,7 +500,9 @@ class LoginRateLimitTests(TestCase):
     def setUp(self):
         # Isolate rate-limit: delete only the key this test uses (test client uses 127.0.0.1)
         cache.delete("login_attempts_127.0.0.1")
-        self.user = User.objects.create_user(email="rate@example.com", password="secret")
+        self.user = User.objects.create_user(
+            email="rate@example.com", password="secret"
+        )
         self.login_url = reverse("api_login")
 
     def test_login_rate_limit_after_failures(self):

--- a/frontend/src/app/contexts/app-context.tsx
+++ b/frontend/src/app/contexts/app-context.tsx
@@ -121,6 +121,12 @@ interface AppContextType {
   register: (data: any) => Promise<void>;
   logout: () => Promise<void>;
   requestPasswordReset: (email: string) => Promise<void>;
+  validatePasswordResetToken: (uid: string, token: string) => Promise<void>;
+  confirmPasswordReset: (
+    uid: string,
+    token: string,
+    newPassword: string
+  ) => Promise<void>;
   updatePreferences: (preferences: {
     dietary?: string[];
     cuisines?: string[];
@@ -703,6 +709,56 @@ export function AppProvider({ children }: { children: ReactNode }) {
     }
   };
 
+  const validatePasswordResetToken = async (uid: string, token: string) => {
+    try {
+      const csrftoken = getCookie('csrftoken') || '';
+      const response = await fetch(apiUrl('/api/auth/validate-password-reset-token/'), {
+        method: 'POST',
+        credentials: 'include',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-CSRFToken': csrftoken,
+        },
+        body: JSON.stringify({ uid, token }),
+      });
+
+      const data = await response.json();
+      if (!response.ok || !data.success || !data.valid) {
+        throw new Error(data.error || 'Invalid or expired reset link');
+      }
+    } catch (error) {
+      console.error('Password reset token validation error:', error);
+      throw error;
+    }
+  };
+
+  const confirmPasswordReset = async (
+    uid: string,
+    token: string,
+    newPassword: string
+  ) => {
+    try {
+      const csrftoken = getCookie('csrftoken') || '';
+      const response = await fetch(apiUrl('/api/auth/confirm-password-reset/'), {
+        method: 'POST',
+        credentials: 'include',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-CSRFToken': csrftoken,
+        },
+        body: JSON.stringify({ uid, token, new_password: newPassword }),
+      });
+
+      const data = await response.json();
+      if (!response.ok || !data.success) {
+        throw new Error(data.error || 'Failed to reset password');
+      }
+    } catch (error) {
+      console.error('Password reset confirmation error:', error);
+      throw error;
+    }
+  };
+
   const logout = async () => {
     try {
       const csrftoken = getCookie('csrftoken') || '';
@@ -1010,6 +1066,8 @@ export function AppProvider({ children }: { children: ReactNode }) {
         register,
         logout,
         requestPasswordReset,
+        validatePasswordResetToken,
+        confirmPasswordReset,
         updatePreferences,
         groups,
         createGroup,

--- a/frontend/src/app/pages/login-page.tsx
+++ b/frontend/src/app/pages/login-page.tsx
@@ -222,7 +222,7 @@ export function LoginPage() {
               <div className="space-y-4 pt-4">
                 <div className="bg-muted/50 p-4 rounded-lg text-sm">
                   <p className="text-muted-foreground">
-                    <strong className="text-foreground">Note:</strong> This is a demo. In a real application, you would receive an email with a secure reset link.
+                    The link expires after a short time for security.
                   </p>
                 </div>
                 <Button

--- a/frontend/src/app/pages/register-page.tsx
+++ b/frontend/src/app/pages/register-page.tsx
@@ -1,7 +1,13 @@
 import { useState } from 'react';
 import { useNavigate } from 'react-router';
 import { Button } from '@/app/components/ui/button';
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/app/components/ui/card';
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/app/components/ui/card';
 import { Input } from '@/app/components/ui/input';
 import { Label } from '@/app/components/ui/label';
 import { Badge } from '@/app/components/ui/badge';
@@ -49,18 +55,14 @@ export function RegisterPage() {
   const [errors, setErrors] = useState<Record<string, string>>({});
 
   const toggleDietary = (option: string) => {
-    setSelectedDietary(prev =>
-      prev.includes(option)
-        ? prev.filter(o => o !== option)
-        : [...prev, option]
+    setSelectedDietary((prev) =>
+      prev.includes(option) ? prev.filter((o) => o !== option) : [...prev, option]
     );
   };
 
   const toggleCuisine = (option: string) => {
-    setSelectedCuisines(prev =>
-      prev.includes(option)
-        ? prev.filter(o => o !== option)
-        : [...prev, option]
+    setSelectedCuisines((prev) =>
+      prev.includes(option) ? prev.filter((o) => o !== option) : [...prev, option]
     );
   };
 
@@ -79,8 +81,8 @@ export function RegisterPage() {
 
     if (!formData.password) {
       newErrors.password = 'Password is required';
-    } else if (formData.password.length < 6) {
-      newErrors.password = 'Password must be at least 6 characters';
+    } else if (formData.password.length < 8) {
+      newErrors.password = 'Password must be at least 8 characters';
     }
 
     if (formData.password !== formData.confirmPassword) {
@@ -100,7 +102,7 @@ export function RegisterPage() {
 
   const handleRegister = async (e: React.FormEvent) => {
     e.preventDefault();
-    
+
     try {
       await register({
         first_name: formData.name.split(' ')[0] || '',
@@ -110,7 +112,7 @@ export function RegisterPage() {
         preferences: {
           cuisines: selectedCuisines,
           dietary: selectedDietary,
-        }
+        },
       });
       navigate('/home');
     } catch (err: any) {
@@ -122,11 +124,14 @@ export function RegisterPage() {
     <div className="min-h-screen bg-gradient-to-br from-purple-500 via-purple-400 to-violet-300 flex items-center justify-center p-4 relative overflow-hidden">
       {/* Subtle background pattern */}
       <div className="absolute inset-0 opacity-5">
-        <div className="absolute inset-0" style={{
-          backgroundImage: `url("data:image/svg+xml,%3Csvg width='60' height='60' viewBox='0 0 60 60' xmlns='http://www.w3.org/2000/svg'%3E%3Cg fill='none' fill-rule='evenodd'%3E%3Cg fill='%23ffffff' fill-opacity='1'%3E%3Cpath d='M36 34v-4h-2v4h-4v2h4v4h2v-4h4v-2h-4zm0-30V0h-2v4h-4v2h4v4h2V6h4V4h-4zM6 34v-4H4v4H0v2h4v4h2v-4h4v-2H6zM6 4V0H4v4H0v2h4v4h2V6h4V4H6z'/%3E%3C/g%3E%3C/g%3E%3C/svg%3E")`,
-        }}></div>
+        <div
+          className="absolute inset-0"
+          style={{
+            backgroundImage: `url("data:image/svg+xml,%3Csvg width='60' height='60' viewBox='0 0 60 60' xmlns='http://www.w3.org/2000/svg'%3E%3Cg fill='none' fill-rule='evenodd'%3E%3Cg fill='%23ffffff' fill-opacity='1'%3E%3Cpath d='M36 34v-4h-2v4h-4v2h4v4h2v-4h4v-2h-4zm0-30V0h-2v4h-4v2h4v4h2V6h4V4h-4zM6 34v-4H4v4H0v2h4v4h2v-4h4v-2H6zM6 4V0H4v4H0v2h4v4h2V6h4V4H6z'/%3E%3C/g%3E%3C/g%3E%3C/svg%3E")`,
+          }}
+        ></div>
       </div>
-      
+
       <Card className="w-full max-w-md bg-gray-50/90 backdrop-blur-sm shadow-2xl border-gray-200/50 relative z-10">
         <CardHeader>
           <div className="w-16 h-16 bg-gradient-to-br from-purple-600 to-violet-700 rounded-2xl flex items-center justify-center mx-auto mb-4 shadow-lg">
@@ -136,8 +141,8 @@ export function RegisterPage() {
             {step === 'account' ? 'Create Account' : 'Set Your Preferences'}
           </CardTitle>
           <CardDescription className="text-center">
-            {step === 'account' 
-              ? 'Join Meal Swipe to find restaurants with your friends' 
+            {step === 'account'
+              ? 'Join Meal Swipe to find restaurants with your friends'
               : 'Help us personalize your restaurant recommendations'}
           </CardDescription>
         </CardHeader>
@@ -176,9 +181,13 @@ export function RegisterPage() {
                   type="password"
                   placeholder="Create a password"
                   value={formData.password}
-                  onChange={(e) => setFormData({ ...formData, password: e.target.value })}
+                  onChange={(e) =>
+                    setFormData({ ...formData, password: e.target.value })
+                  }
                 />
-                {errors.password && <p className="text-sm text-red-600">{errors.password}</p>}
+                {errors.password && (
+                  <p className="text-sm text-red-600">{errors.password}</p>
+                )}
               </div>
 
               <div className="space-y-2">
@@ -188,12 +197,19 @@ export function RegisterPage() {
                   type="password"
                   placeholder="Re-enter your password"
                   value={formData.confirmPassword}
-                  onChange={(e) => setFormData({ ...formData, confirmPassword: e.target.value })}
+                  onChange={(e) =>
+                    setFormData({ ...formData, confirmPassword: e.target.value })
+                  }
                 />
-                {errors.confirmPassword && <p className="text-sm text-red-600">{errors.confirmPassword}</p>}
+                {errors.confirmPassword && (
+                  <p className="text-sm text-red-600">{errors.confirmPassword}</p>
+                )}
               </div>
 
-              <Button type="submit" className="w-full bg-purple-700 hover:bg-purple-800 text-white shadow-lg">
+              <Button
+                type="submit"
+                className="w-full bg-purple-700 hover:bg-purple-800 text-white shadow-lg"
+              >
                 Continue
               </Button>
 
@@ -244,7 +260,9 @@ export function RegisterPage() {
                   {CUISINE_OPTIONS.map((option) => (
                     <Badge
                       key={option}
-                      variant={selectedCuisines.includes(option) ? 'default' : 'outline'}
+                      variant={
+                        selectedCuisines.includes(option) ? 'default' : 'outline'
+                      }
                       className={`cursor-pointer ${
                         selectedCuisines.includes(option)
                           ? 'bg-gradient-to-r from-orange-500 to-pink-500 text-white'
@@ -274,8 +292,10 @@ export function RegisterPage() {
                   Complete Registration
                 </Button>
               </div>
-              
-              {errors.form && <p className="text-sm text-red-600 text-center">{errors.form}</p>}
+
+              {errors.form && (
+                <p className="text-sm text-red-600 text-center">{errors.form}</p>
+              )}
 
               <p className="text-xs text-center text-muted-foreground">
                 You can always update your preferences later

--- a/frontend/src/app/pages/reset-password-page.tsx
+++ b/frontend/src/app/pages/reset-password-page.tsx
@@ -1,0 +1,146 @@
+import { useEffect, useState } from 'react';
+import { useNavigate, useParams } from 'react-router';
+import { useApp } from '@/app/contexts/app-context';
+import { Button } from '@/app/components/ui/button';
+import { Input } from '@/app/components/ui/input';
+import { Label } from '@/app/components/ui/label';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/app/components/ui/card';
+
+export function ResetPasswordPage() {
+  const { uid = '', token = '' } = useParams();
+  const navigate = useNavigate();
+  const { validatePasswordResetToken, confirmPasswordReset } = useApp();
+
+  const [isValidating, setIsValidating] = useState(true);
+  const [isValidLink, setIsValidLink] = useState(false);
+  const [newPassword, setNewPassword] = useState('');
+  const [confirmPassword, setConfirmPassword] = useState('');
+  const [error, setError] = useState('');
+  const [success, setSuccess] = useState(false);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  useEffect(() => {
+    const validateLink = async () => {
+      if (!uid || !token) {
+        setError('Invalid or expired reset link.');
+        setIsValidating(false);
+        setIsValidLink(false);
+        return;
+      }
+
+      try {
+        await validatePasswordResetToken(uid, token);
+        setIsValidLink(true);
+      } catch (err: unknown) {
+        const message = err instanceof Error ? err.message : 'Invalid or expired reset link.';
+        setError(message);
+        setIsValidLink(false);
+      } finally {
+        setIsValidating(false);
+      }
+    };
+
+    validateLink();
+  }, [uid, token, validatePasswordResetToken]);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError('');
+
+    if (!newPassword || !confirmPassword) {
+      setError('Please enter and confirm your new password.');
+      return;
+    }
+
+    if (newPassword !== confirmPassword) {
+      setError('Passwords do not match.');
+      return;
+    }
+
+    try {
+      setIsSubmitting(true);
+      await confirmPasswordReset(uid, token, newPassword);
+      setSuccess(true);
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : 'Failed to reset password.';
+      setError(message);
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-purple-500 via-purple-400 to-violet-300 p-4">
+      <Card className="w-full max-w-md bg-gray-50/90 backdrop-blur-sm shadow-2xl border-gray-200/50">
+        <CardHeader>
+          <CardTitle className="text-center text-2xl text-gray-900">Reset Password</CardTitle>
+          <CardDescription className="text-center">
+            Create a new password for your Meal Swipe account.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          {isValidating ? (
+            <p className="text-sm text-muted-foreground text-center">Validating reset link...</p>
+          ) : success ? (
+            <div className="space-y-4">
+              <p className="text-sm text-green-700 text-center">
+                Your password has been reset successfully.
+              </p>
+              <Button
+                type="button"
+                className="w-full bg-purple-700 hover:bg-purple-800 text-white shadow-lg"
+                onClick={() => navigate('/')}
+              >
+                Back to Login
+              </Button>
+            </div>
+          ) : !isValidLink ? (
+            <div className="space-y-4">
+              <p className="text-sm text-red-600 text-center">{error || 'Invalid or expired reset link.'}</p>
+              <Button
+                type="button"
+                className="w-full bg-purple-700 hover:bg-purple-800 text-white shadow-lg"
+                onClick={() => navigate('/')}
+              >
+                Back to Login
+              </Button>
+            </div>
+          ) : (
+            <form onSubmit={handleSubmit} className="space-y-4">
+              <div className="space-y-2">
+                <Label htmlFor="newPassword">New Password</Label>
+                <Input
+                  id="newPassword"
+                  type="password"
+                  placeholder="Enter new password"
+                  value={newPassword}
+                  onChange={(e) => setNewPassword(e.target.value)}
+                  required
+                />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="confirmPassword">Confirm New Password</Label>
+                <Input
+                  id="confirmPassword"
+                  type="password"
+                  placeholder="Confirm new password"
+                  value={confirmPassword}
+                  onChange={(e) => setConfirmPassword(e.target.value)}
+                  required
+                />
+              </div>
+              {error && <p className="text-sm text-red-600">{error}</p>}
+              <Button
+                type="submit"
+                className="w-full bg-purple-700 hover:bg-purple-800 text-white shadow-lg"
+                disabled={isSubmitting}
+              >
+                {isSubmitting ? 'Saving...' : 'Save New Password'}
+              </Button>
+            </form>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/frontend/src/app/routes.ts
+++ b/frontend/src/app/routes.ts
@@ -14,6 +14,7 @@ import { AddRestaurantPage } from '@/app/pages/add-restaurant-page';
 import { EditRestaurantPage } from '@/app/pages/edit-restaurant-page';
 import { VenueLoginPage } from '@/app/pages/venue-login-page';
 import { VenueRegisterPage } from '@/app/pages/venue-register-page';
+import { ResetPasswordPage } from '@/app/pages/reset-password-page';
 
 export const router = createBrowserRouter([
   {
@@ -27,6 +28,10 @@ export const router = createBrowserRouter([
       {
         path: 'register',
         Component: RegisterPage,
+      },
+      {
+        path: 'reset-password/:uid/:token',
+        Component: ResetPasswordPage,
       },
       {
         path: 'home',


### PR DESCRIPTION
- Replace Resend API with Django send_mail() + Gmail SMTP (email_service.py)
- Add CertifiSMTPBackend to fix macOS SSL cert verification (smtp_backend.py)
- Add reset-password-page.tsx with token validation and form
- Enforce Django AUTH_PASSWORD_VALIDATORS on registration (forms.py)
- Update frontend min password length from 6 to 8 chars
- Add Email / Password Reset section to README
- Add certifi to requirements.txt
- All 27 tests passing