### PR TITLE
Feature/travis ci deployment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,6 +39,8 @@ after_success:
 before_deploy:
   # Package only the backend directory for backend EB deploy
   - (cd backend && zip -r ../backend-deploy.zip . --exclude "*.pyc" --exclude "*/__pycache__/*" --exclude ".venv/*" --exclude "db.sqlite3" --exclude "db.sqlite3.bak" --exclude ".env" --exclude ".DS_Store" --exclude ".elasticbeanstalk/*" --exclude "aws-elastic-beanstalk-cli-setup/*")
+  # Inject backend EB URL into Nginx config before packaging
+  - sed -i "s|BACKEND_EB_URL|$EB_DEV_BACKEND_URL|g" frontend/.platform/nginx/conf.d/elasticbeanstalk/10_api_proxy.conf
   # Package the pre-built frontend dist/, Procfile, package.json, lockfile, and .platform/ Nginx config
   - (cd frontend && zip -r ../frontend-deploy.zip dist/ Procfile package.json package-lock.json .platform/)
 

--- a/frontend/.platform/nginx/conf.d/elasticbeanstalk/10_api_proxy.conf
+++ b/frontend/.platform/nginx/conf.d/elasticbeanstalk/10_api_proxy.conf
@@ -1,8 +1,8 @@
 location /api/ {
-    proxy_pass http://mealswipe-backend-env-1.eba-8akuzyp3.us-east-2.elasticbeanstalk.com;
+    proxy_pass http://BACKEND_EB_URL;
     proxy_http_version 1.1;
 
-    proxy_set_header Host mealswipe-backend-env-1.eba-8akuzyp3.us-east-2.elasticbeanstalk.com;
+    proxy_set_header Host BACKEND_EB_URL;
     proxy_set_header X-Real-IP $remote_addr;
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     proxy_set_header X-Forwarded-Proto $scheme;


### PR DESCRIPTION
This pull request improves the deployment configuration by making the Elastic Beanstalk (EB) environment more flexible and easier to configure for different environments. The main changes include parameterizing the EB settings in `.travis.yml` and updating the Nginx configuration to use a dynamic backend URL, which is injected during the build process.

**Deployment configuration improvements:**

* Updated `.travis.yml` to use environment variables for all Elastic Beanstalk deployment settings, allowing for easier configuration across different environments. [[1]](diffhunk://#diff-6ac3f79fc25d95cd1e3d51da53a4b21b939437392578a35ae8cd6d5366ca5485R42-R54) [[2]](diffhunk://#diff-6ac3f79fc25d95cd1e3d51da53a4b21b939437392578a35ae8cd6d5366ca5485L61-R66)
* Added a step to inject the actual backend EB URL into the frontend Nginx config before packaging, ensuring the correct backend endpoint is used after deployment.

**Nginx configuration changes:**

* Modified `frontend/.platform/nginx/conf.d/elasticbeanstalk/10_api_proxy.conf` to use a placeholder (`BACKEND_EB_URL`) for the backend URL and host, which is replaced during the build process.