### PR TITLE
Fix Nginx proxy_pass to resolve backend hostname at runtime

### DIFF
--- a/frontend/.platform/nginx/conf.d/elasticbeanstalk/10_api_proxy.conf
+++ b/frontend/.platform/nginx/conf.d/elasticbeanstalk/10_api_proxy.conf
@@ -1,5 +1,7 @@
 location /api/ {
-    proxy_pass http://BACKEND_EB_URL;
+    resolver 169.254.169.253 valid=30s;
+    set $backend "BACKEND_EB_URL";
+    proxy_pass http://$backend;
     proxy_http_version 1.1;
 
     proxy_set_header Host BACKEND_EB_URL;


### PR DESCRIPTION
This pull request improves the deployment configuration by making the Elastic Beanstalk (EB) environment more flexible and easier to configure for different environments. The main changes include parameterizing the EB settings in `.travis.yml` and updating the Nginx configuration to use a dynamic backend URL, which is injected during the build process.

**Deployment configuration improvements:**

* Updated `.travis.yml` to use environment variables for all Elastic Beanstalk deployment settings, allowing for easier configuration across different environments. [[1]](diffhunk://#diff-6ac3f79fc25d95cd1e3d51da53a4b21b939437392578a35ae8cd6d5366ca5485R42-R54) [[2]](diffhunk://#diff-6ac3f79fc25d95cd1e3d51da53a4b21b939437392578a35ae8cd6d5366ca5485L61-R66)
* Added a step to inject the actual backend EB URL into the frontend Nginx config before packaging, ensuring the correct backend endpoint is used after deployment.

**Nginx configuration changes:**

* Modified `frontend/.platform/nginx/conf.d/elasticbeanstalk/10_api_proxy.conf` to use a placeholder (`BACKEND_EB_URL`) for the backend URL and host, which is replaced during the build process.