### PR TITLE
Add psycopg2-binary for PostgreSQL support on EB

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -3,3 +3,4 @@ django-cors-headers==4.7.0
 gunicorn==22.0.0
 python-dotenv==1.0.1
 certifi==2026.2.25
+psycopg2-binary==2.9.10


### PR DESCRIPTION
This pull request adds a new dependency to the backend requirements, specifically for PostgreSQL database support.

Dependency management:

* Added `psycopg2-binary==2.9.10` to `backend/requirements.txt` to enable PostgreSQL database connectivity.