### PR TITLE
fix: add borough filtering to swipe sessions and fix placeholder images

### DIFF
--- a/backend/groups/migrations/0005_swipeevent_borough_neighborhood.py
+++ b/backend/groups/migrations/0005_swipeevent_borough_neighborhood.py
@@ -1,0 +1,21 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("groups", "0004_merge_20260330_0201"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="swipeevent",
+            name="borough",
+            field=models.CharField(blank=True, max_length=50),
+        ),
+        migrations.AddField(
+            model_name="swipeevent",
+            name="neighborhood",
+            field=models.CharField(blank=True, max_length=100),
+        ),
+    ]

--- a/backend/groups/migrations/0005_swipeevent_borough_neighborhood.py
+++ b/backend/groups/migrations/0005_swipeevent_borough_neighborhood.py
@@ -11,11 +11,11 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name="swipeevent",
             name="borough",
-            field=models.CharField(blank=True, max_length=50),
+            field=models.CharField(blank=True, max_length=50, default=""),
         ),
         migrations.AddField(
             model_name="swipeevent",
             name="neighborhood",
-            field=models.CharField(blank=True, max_length=100),
+            field=models.CharField(blank=True, max_length=100, default=""),
         ),
     ]

--- a/backend/groups/migrations/0005_swipeevent_borough_neighborhood.py
+++ b/backend/groups/migrations/0005_swipeevent_borough_neighborhood.py
@@ -11,11 +11,11 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name="swipeevent",
             name="borough",
-            field=models.CharField(blank=True, max_length=50, default=""),
+            field=models.CharField(blank=True, max_length=50),
         ),
         migrations.AddField(
             model_name="swipeevent",
             name="neighborhood",
-            field=models.CharField(blank=True, max_length=100, default=""),
+            field=models.CharField(blank=True, max_length=100),
         ),
     ]

--- a/backend/groups/models.py
+++ b/backend/groups/models.py
@@ -93,6 +93,8 @@ class SwipeEvent(models.Model):
         blank=True,
         related_name="matched_events",
     )
+    borough = models.CharField(max_length=50, blank=True)
+    neighborhood = models.CharField(max_length=100, blank=True)
     created_at = models.DateTimeField(auto_now_add=True)
     updated_at = models.DateTimeField(auto_now=True)
 

--- a/backend/groups/tests.py
+++ b/backend/groups/tests.py
@@ -783,11 +783,13 @@ class SwipeEventAPITests(TestCase):
         self.client.login(email="leader@nyu.edu", password="pass123")
         response = self.client.post(
             f"/api/groups/{self.group.id}/events/",
-            json.dumps({
-                "name": "Brooklyn Dinner",
-                "borough": "Brooklyn",
-                "neighborhood": "DUMBO",
-            }),
+            json.dumps(
+                {
+                    "name": "Brooklyn Dinner",
+                    "borough": "Brooklyn",
+                    "neighborhood": "DUMBO",
+                }
+            ),
             content_type="application/json",
         )
         self.assertEqual(response.status_code, 201)

--- a/backend/groups/tests.py
+++ b/backend/groups/tests.py
@@ -728,6 +728,96 @@ class SwipeEventAPITests(TestCase):
         response = self.client.get(f"/api/groups/{self.group.id}/events/99999/results/")
         self.assertEqual(response.status_code, 404)
 
+    def test_venues_filtered_by_borough(self):
+        """Venues are filtered to match the event's borough."""
+        # Set boroughs on venues
+        self.venue1.borough = "Manhattan"
+        self.venue1.save()
+        self.venue2.borough = "Brooklyn"
+        self.venue2.save()
+        self.venue3.borough = "Manhattan"
+        self.venue3.save()
+
+        event = SwipeEvent.objects.create(
+            group=self.group,
+            name="Manhattan Dinner",
+            created_by=self.leader,
+            borough="Manhattan",
+        )
+
+        self.client.login(email="leader@nyu.edu", password="pass123")
+        response = self.client.get(
+            f"/api/groups/{self.group.id}/events/{event.id}/venues/"
+        )
+        data = response.json()
+        venue_names = [v["name"] for v in data["venues"]]
+        # Only Manhattan venues should appear
+        self.assertIn("Pizza Place", venue_names)
+        self.assertNotIn("Sushi Spot", venue_names)  # Brooklyn
+
+    def test_venues_no_borough_filter_returns_all(self):
+        """When event has no borough set, all venues are returned."""
+        self.venue1.borough = "Manhattan"
+        self.venue1.save()
+        self.venue2.borough = "Brooklyn"
+        self.venue2.save()
+
+        event = SwipeEvent.objects.create(
+            group=self.group,
+            name="Any Location",
+            created_by=self.leader,
+            borough="",
+        )
+
+        self.client.login(email="leader@nyu.edu", password="pass123")
+        response = self.client.get(
+            f"/api/groups/{self.group.id}/events/{event.id}/venues/"
+        )
+        data = response.json()
+        venue_names = [v["name"] for v in data["venues"]]
+        self.assertIn("Pizza Place", venue_names)
+        self.assertIn("Sushi Spot", venue_names)
+
+    def test_create_event_with_borough(self):
+        """Creating an event with borough/neighborhood stores them."""
+        self.client.login(email="leader@nyu.edu", password="pass123")
+        response = self.client.post(
+            f"/api/groups/{self.group.id}/events/",
+            json.dumps({
+                "name": "Brooklyn Dinner",
+                "borough": "Brooklyn",
+                "neighborhood": "DUMBO",
+            }),
+            content_type="application/json",
+        )
+        self.assertEqual(response.status_code, 201)
+        data = response.json()
+        self.assertEqual(data["event"]["borough"], "Brooklyn")
+        self.assertEqual(data["event"]["neighborhood"], "DUMBO")
+
+    def test_venues_filtered_by_borough_case_insensitive(self):
+        """Borough filtering is case-insensitive."""
+        self.venue1.borough = "manhattan"
+        self.venue1.save()
+        self.venue2.borough = "Brooklyn"
+        self.venue2.save()
+
+        event = SwipeEvent.objects.create(
+            group=self.group,
+            name="Manhattan Dinner",
+            created_by=self.leader,
+            borough="Manhattan",
+        )
+
+        self.client.login(email="leader@nyu.edu", password="pass123")
+        response = self.client.get(
+            f"/api/groups/{self.group.id}/events/{event.id}/venues/"
+        )
+        data = response.json()
+        venue_names = [v["name"] for v in data["venues"]]
+        self.assertIn("Pizza Place", venue_names)
+        self.assertNotIn("Sushi Spot", venue_names)
+
 
 class GroupManagementAPITests(TestCase):
     """Tests for group CRUD, invite, remove, make leader, leave endpoints."""

--- a/backend/groups/views.py
+++ b/backend/groups/views.py
@@ -618,6 +618,8 @@ def _event_to_json(event):
         "status": event.status,
         "created_by": event.created_by_id,
         "matched_venue_id": event.matched_venue_id,
+        "borough": event.borough,
+        "neighborhood": event.neighborhood,
         "created_at": event.created_at.isoformat(),
     }
 
@@ -669,7 +671,7 @@ def _venue_to_swipe_json(venue):
         "name": venue.name,
         "cuisine": [venue.cuisine_type.name] if venue.cuisine_type else [],
         "sanitationGrade": venue.sanitation_grade or "P",
-        "images": photos if photos else ["/placeholder-restaurant.jpg"],
+        "images": photos if photos else [],
         "badges": badges,
         "address": (
             f"{venue.street_address}, {venue.borough}".strip(", ")
@@ -741,6 +743,8 @@ def api_swipe_events(request, group_id):
                 group=group,
                 name=name,
                 created_by=request.user,
+                borough=(data.get("borough") or "").strip(),
+                neighborhood=(data.get("neighborhood") or "").strip(),
             )
             return JsonResponse(
                 {"success": True, "event": _event_to_json(event)}, status=201
@@ -787,6 +791,12 @@ def api_swipe_event_venues(request, group_id, event_id):
         )
 
         venues_qs = Venue.objects.filter(is_active=True)
+
+        # --- Location-based filtering ---
+        if event.borough:
+            venues_qs = venues_qs.filter(borough__iexact=event.borough)
+        if event.neighborhood:
+            venues_qs = venues_qs.filter(neighborhood__iexact=event.neighborhood)
 
         # --- Preference-based filtering ---
         preferences = UserPreference.objects.filter(

--- a/backend/groups/views.py
+++ b/backend/groups/views.py
@@ -671,7 +671,7 @@ def _venue_to_swipe_json(venue):
         "name": venue.name,
         "cuisine": [venue.cuisine_type.name] if venue.cuisine_type else [],
         "sanitationGrade": venue.sanitation_grade or "P",
-        "images": photos if photos else [""],
+        "images": photos if photos else [],
         "badges": badges,
         "address": (
             f"{venue.street_address}, {venue.borough}".strip(", ")

--- a/backend/groups/views.py
+++ b/backend/groups/views.py
@@ -671,7 +671,7 @@ def _venue_to_swipe_json(venue):
         "name": venue.name,
         "cuisine": [venue.cuisine_type.name] if venue.cuisine_type else [],
         "sanitationGrade": venue.sanitation_grade or "P",
-        "images": photos if photos else [],
+        "images": photos if photos else [""],
         "badges": badges,
         "address": (
             f"{venue.street_address}, {venue.borough}".strip(", ")

--- a/frontend/src/app/components/restaurant-card.tsx
+++ b/frontend/src/app/components/restaurant-card.tsx
@@ -174,7 +174,7 @@ export function RestaurantCard({ restaurant, onSwipe }: RestaurantCardProps) {
               {/* Image Section */}
               <div className="relative h-96">
                 <ImageWithFallback
-                  src={restaurant.images[currentImageIndex]}
+                  src={restaurant.images?.[currentImageIndex] ?? ''}
                   alt={restaurant.name}
                   className="w-full h-full object-cover"
                 />

--- a/frontend/src/app/components/restaurant-card.tsx
+++ b/frontend/src/app/components/restaurant-card.tsx
@@ -174,9 +174,7 @@ export function RestaurantCard({ restaurant, onSwipe }: RestaurantCardProps) {
               {/* Image Section */}
               <div className="relative h-96">
                 <ImageWithFallback
-                  src={restaurant.images && restaurant.images.length > 0
-                    ? restaurant.images[currentImageIndex]
-                    : '/placeholder.png'}
+                  src={restaurant.images[currentImageIndex]}
                   alt={restaurant.name}
                   className="w-full h-full object-cover"
                 />

--- a/frontend/src/app/components/restaurant-card.tsx
+++ b/frontend/src/app/components/restaurant-card.tsx
@@ -7,6 +7,7 @@ import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription } f
 import { X, Heart, Info, MapPin, Calendar, AlertTriangle, ExternalLink, Star, Users, Ticket, ChevronLeft, ChevronRight, AlertCircle } from 'lucide-react';
 import { motion, AnimatePresence } from 'motion/react';
 import { useApp } from '@/app/contexts/app-context';
+import { ImageWithFallback } from '@/app/components/figma/ImageWithFallback';
 
 interface RestaurantCardProps {
   restaurant: Restaurant;
@@ -172,8 +173,8 @@ export function RestaurantCard({ restaurant, onSwipe }: RestaurantCardProps) {
 
               {/* Image Section */}
               <div className="relative h-96">
-                <img
-                  src={restaurant.images[currentImageIndex] || '/placeholder-restaurant.jpg'}
+                <ImageWithFallback
+                  src={restaurant.images[currentImageIndex]}
                   alt={restaurant.name}
                   className="w-full h-full object-cover"
                 />

--- a/frontend/src/app/components/restaurant-card.tsx
+++ b/frontend/src/app/components/restaurant-card.tsx
@@ -174,7 +174,9 @@ export function RestaurantCard({ restaurant, onSwipe }: RestaurantCardProps) {
               {/* Image Section */}
               <div className="relative h-96">
                 <ImageWithFallback
-                  src={restaurant.images[currentImageIndex]}
+                  src={restaurant.images && restaurant.images.length > 0
+                    ? restaurant.images[currentImageIndex]
+                    : '/placeholder.png'}
                   alt={restaurant.name}
                   className="w-full h-full object-cover"
                 />

--- a/frontend/src/app/contexts/app-context.tsx
+++ b/frontend/src/app/contexts/app-context.tsx
@@ -85,6 +85,8 @@ export interface SwipeEvent {
   status: 'pending' | 'active' | 'completed';
   createdAt: string;
   matchedRestaurantId?: string;
+  borough?: string;
+  neighborhood?: string;
 }
 
 export interface Swipe {
@@ -192,7 +194,7 @@ interface AppContextType {
   currentGroup: Group | null;
   setCurrentGroup: (group: Group | null) => void;
   swipeEvents: SwipeEvent[];
-  createSwipeEvent: (groupId: string, name: string) => Promise<SwipeEvent>;
+  createSwipeEvent: (groupId: string, name: string, borough?: string, neighborhood?: string) => Promise<SwipeEvent>;
   fetchSwipeEvents: (groupId: string) => Promise<void>;
   currentSwipeEvent: SwipeEvent | null;
   setCurrentSwipeEvent: (event: SwipeEvent | null) => void;
@@ -1297,7 +1299,9 @@ export function AppProvider({ children }: { children: ReactNode }) {
 
   const createSwipeEvent = async (
     groupId: string,
-    name: string
+    name: string,
+    borough?: string,
+    neighborhood?: string
   ): Promise<SwipeEvent> => {
     const csrftoken = getCookie('csrftoken') || '';
     const response = await fetch(apiUrl(`/api/groups/${groupId}/events/`), {
@@ -1307,7 +1311,7 @@ export function AppProvider({ children }: { children: ReactNode }) {
         'Content-Type': 'application/json',
         'X-CSRFToken': csrftoken,
       },
-      body: JSON.stringify({ name }),
+      body: JSON.stringify({ name, borough, neighborhood }),
     });
     const data = await response.json();
     if (!response.ok) throw new Error(data.error || 'Failed to create event');
@@ -1321,6 +1325,8 @@ export function AppProvider({ children }: { children: ReactNode }) {
       matchedRestaurantId: data.event.matched_venue_id
         ? String(data.event.matched_venue_id)
         : undefined,
+      borough: data.event.borough || '',
+      neighborhood: data.event.neighborhood || '',
     };
 
     setSwipeEvents((prev) => [...prev, newEvent]);

--- a/frontend/src/app/pages/match-page.tsx
+++ b/frontend/src/app/pages/match-page.tsx
@@ -9,6 +9,7 @@ import { MapPin, AlertTriangle, ExternalLink, PartyPopper, Users, ArrowLeft, Sta
 import { motion, AnimatePresence } from 'motion/react';
 import Confetti from 'react-confetti';
 import { Separator } from '@/app/components/ui/separator';
+import { ImageWithFallback } from '@/app/components/figma/ImageWithFallback';
 
 export function MatchPage() {
   const { eventId } = useParams();
@@ -151,8 +152,8 @@ export function MatchPage() {
                 <Card className="overflow-hidden shadow-xl">
                   {/* Hero Image */}
                   <div className="relative h-64">
-                    <img 
-                      src={matchedRestaurant.images[0]} 
+                    <ImageWithFallback
+                      src={matchedRestaurant.images[0]}
                       alt={matchedRestaurant.name}
                       className="w-full h-full object-cover"
                     />

--- a/frontend/src/app/pages/match-page.tsx
+++ b/frontend/src/app/pages/match-page.tsx
@@ -153,7 +153,7 @@ export function MatchPage() {
                   {/* Hero Image */}
                   <div className="relative h-64">
                     <ImageWithFallback
-                      src={matchedRestaurant.images[0]}
+                      src={matchedRestaurant.images?.[0] ?? ''}
                       alt={matchedRestaurant.name}
                       className="w-full h-full object-cover"
                     />

--- a/frontend/src/app/pages/match-page.tsx
+++ b/frontend/src/app/pages/match-page.tsx
@@ -152,11 +152,18 @@ export function MatchPage() {
                 <Card className="overflow-hidden shadow-xl">
                   {/* Hero Image */}
                   <div className="relative h-64">
-                    <ImageWithFallback
-                      src={matchedRestaurant.images[0]}
-                      alt={matchedRestaurant.name}
-                      className="w-full h-full object-cover"
-                    />
+                    {matchedRestaurant.images && matchedRestaurant.images.length > 0 ? (
+                      <ImageWithFallback
+                        src={matchedRestaurant.images[0]}
+                        alt={matchedRestaurant.name}
+                        className="w-full h-full object-cover"
+                      />
+                    ) : (
+                      <div
+                        className="w-full h-full bg-muted"
+                        aria-hidden="true"
+                      />
+                    )}
                     
                     {/* Gradient Overlay */}
                     <div className="absolute inset-0 bg-gradient-to-t from-black/60 via-transparent to-transparent" />

--- a/frontend/src/app/pages/match-page.tsx
+++ b/frontend/src/app/pages/match-page.tsx
@@ -152,18 +152,11 @@ export function MatchPage() {
                 <Card className="overflow-hidden shadow-xl">
                   {/* Hero Image */}
                   <div className="relative h-64">
-                    {matchedRestaurant.images && matchedRestaurant.images.length > 0 ? (
-                      <ImageWithFallback
-                        src={matchedRestaurant.images[0]}
-                        alt={matchedRestaurant.name}
-                        className="w-full h-full object-cover"
-                      />
-                    ) : (
-                      <div
-                        className="w-full h-full bg-muted"
-                        aria-hidden="true"
-                      />
-                    )}
+                    <ImageWithFallback
+                      src={matchedRestaurant.images[0]}
+                      alt={matchedRestaurant.name}
+                      className="w-full h-full object-cover"
+                    />
                     
                     {/* Gradient Overlay */}
                     <div className="absolute inset-0 bg-gradient-to-t from-black/60 via-transparent to-transparent" />

--- a/frontend/src/app/pages/plan-event-page.tsx
+++ b/frontend/src/app/pages/plan-event-page.tsx
@@ -30,13 +30,13 @@ import {
 
 // NYU Locations organized by area
 const nyuLocations = [
-  { value: "washington-square", label: "Washington Square Campus", area: "Greenwich Village" },
-  { value: "kimmel-center", label: "Kimmel Center", area: "Greenwich Village" },
-  { value: "bobst-library", label: "Bobst Library", area: "Greenwich Village" },
-  { value: "stern-school", label: "Stern School of Business", area: "Greenwich Village" },
-  { value: "tisch-school", label: "Tisch School of the Arts", area: "Greenwich Village" },
-  { value: "tandon-school", label: "Tandon School of Engineering", area: "Downtown Brooklyn" },
-  { value: "brooklyn-campus", label: "Brooklyn Campus", area: "Downtown Brooklyn" },
+  { value: "washington-square", label: "Washington Square Campus", area: "Greenwich Village", borough: "Manhattan" },
+  { value: "kimmel-center", label: "Kimmel Center", area: "Greenwich Village", borough: "Manhattan" },
+  { value: "bobst-library", label: "Bobst Library", area: "Greenwich Village", borough: "Manhattan" },
+  { value: "stern-school", label: "Stern School of Business", area: "Greenwich Village", borough: "Manhattan" },
+  { value: "tisch-school", label: "Tisch School of the Arts", area: "Greenwich Village", borough: "Manhattan" },
+  { value: "tandon-school", label: "Tandon School of Engineering", area: "Downtown Brooklyn", borough: "Brooklyn" },
+  { value: "brooklyn-campus", label: "Brooklyn Campus", area: "Downtown Brooklyn", borough: "Brooklyn" },
 ];
 
 // Manhattan neighborhoods
@@ -115,23 +115,35 @@ export function PlanEventPage() {
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
 
-    // Build location string
+    // Build location string and determine borough/neighborhood for filtering
     let locationString = "";
+    let eventBorough = "";
+    let eventNeighborhood = "";
     if (locationType === "nyu") {
       const selectedNYU = nyuLocations.find(l => l.value === nyuLocation);
       locationString = selectedNYU?.label || "";
+      eventBorough = selectedNYU?.borough || "Manhattan";
+      eventNeighborhood = selectedNYU?.area || "";
     } else {
-      const selectedNeighborhood = 
+      const boroughMap: Record<string, string> = {
+        manhattan: "Manhattan",
+        brooklyn: "Brooklyn",
+        queens: "Queens",
+        bronx: "Bronx",
+      };
+      const selectedNeighborhood =
         borough === "manhattan" ? manhattanAreas.find(a => a.value === neighborhood) :
         borough === "brooklyn" ? brooklynAreas.find(a => a.value === neighborhood) :
         borough === "queens" ? queensAreas.find(a => a.value === neighborhood) :
         bronxAreas.find(a => a.value === neighborhood);
       locationString = selectedNeighborhood?.label || "";
+      eventBorough = boroughMap[borough] || "Manhattan";
+      eventNeighborhood = selectedNeighborhood?.label || "";
     }
 
     const finalName = eventName || `Dining Plan - ${locationString}`;
     try {
-      const newEvent = await createSwipeEvent(group.id, finalName);
+      const newEvent = await createSwipeEvent(group.id, finalName, eventBorough, eventNeighborhood);
       setCurrentGroup(group);
       setCurrentSwipeEvent(newEvent);
       navigate(`/swipe/${newEvent.id}`);


### PR DESCRIPTION
Swipe sessions now filter venues by the borough/neighborhood selected when planning an event. Also replaced broken placeholder image path with ImageWithFallback component for proper fallback display.