### PR TITLE
fix: resolve chat scrolling, DM/group ID namespace collision, and mes…

### DIFF
--- a/frontend/src/app/components/chat-sidebar.tsx
+++ b/frontend/src/app/components/chat-sidebar.tsx
@@ -2,7 +2,6 @@ import { useState, useRef, useEffect, useMemo } from 'react';
 import { useApp } from '@/app/contexts/app-context';
 import { Button } from '@/app/components/ui/button';
 import { Input } from '@/app/components/ui/input';
-import { ScrollArea } from '@/app/components/ui/scroll-area';
 import { X, Send } from 'lucide-react';
 
 interface ChatSidebarProps {
@@ -49,7 +48,7 @@ export function ChatSidebar({ groupId, onClose }: ChatSidebarProps) {
       </div>
 
       {/* Messages */}
-      <ScrollArea className="flex-1 p-4" ref={scrollRef}>
+      <div ref={scrollRef} className="flex-1 min-h-0 overflow-y-auto p-4">
         <div className="space-y-4">
           {messages.map((msg) => (
             <div key={msg.id}>
@@ -82,7 +81,7 @@ export function ChatSidebar({ groupId, onClose }: ChatSidebarProps) {
             </div>
           ))}
         </div>
-      </ScrollArea>
+      </div>
 
       {/* Input */}
       <form onSubmit={handleSend} className="p-4 border-t flex gap-2">

--- a/frontend/src/app/components/floating-chat.tsx
+++ b/frontend/src/app/components/floating-chat.tsx
@@ -17,7 +17,8 @@ import { useApp } from '@/app/contexts/app-context';
 type ConversationType = 'group' | 'dm';
 
 interface Conversation {
-  id: string;
+  id: string;      // namespaced UI key: "group-{id}" or "dm-{id}"
+  chatId: string;  // raw backend ID for message/API calls
   type: ConversationType;
   name: string;
   lastMessage?: string;
@@ -37,7 +38,8 @@ export function FloatingChat() {
   // Build conversation list
   const conversations: Conversation[] = [
     ...groups.map(g => ({
-      id: g.id,
+      id: `group-${g.id}`,
+      chatId: g.id,
       type: 'group' as ConversationType,
       name: g.name,
       isGroup: true,
@@ -45,14 +47,14 @@ export function FloatingChat() {
       lastMessageTime: chatMessages[g.id]?.slice(-1)[0]?.timestamp
     })),
     ...dmConversations.map(dm => {
-      // Get the other participant's name
       const otherParticipantName = dm.participantNames.find(name => name !== currentUser?.name) || 'Unknown';
       return {
-        id: dm.id,
+        id: `dm-${dm.id}`,
+        chatId: `dm-${dm.id}`,
         type: 'dm' as ConversationType,
         name: otherParticipantName,
         isGroup: false,
-        lastMessage: chatMessages[dm.id]?.slice(-1)[0]?.message,
+        lastMessage: chatMessages[`dm-${dm.id}`]?.slice(-1)[0]?.message,
         lastMessageTime: dm.lastMessageTime
       };
     })
@@ -74,8 +76,9 @@ export function FloatingChat() {
   }, [conversations.length, selectedConversationId]); // eslint-disable-line react-hooks/exhaustive-deps
 
   const selectedConversation = conversations.find(c => c.id === selectedConversationId);
-  const messages = useMemo(() => selectedConversationId ? chatMessages[selectedConversationId] || [] : [], [selectedConversationId, chatMessages]);
-  const isLeader = selectedConversation?.isGroup ? groups.find(g => g.id === selectedConversationId)?.members.find(m => m.userId === currentUser?.id)?.isLeader : false;
+  const selectedChatId = selectedConversation?.chatId ?? '';
+  const messages = useMemo(() => selectedChatId ? chatMessages[selectedChatId] || [] : [], [selectedChatId, chatMessages]);
+  const isLeader = selectedConversation?.isGroup ? groups.find(g => g.id === selectedChatId)?.members.find(m => m.userId === currentUser?.id)?.isLeader : false;
 
   // Auto-scroll to bottom when messages change
   useEffect(() => {
@@ -83,9 +86,9 @@ export function FloatingChat() {
   }, [messages]);
 
   const handleSendMessage = () => {
-    if (!newMessage.trim() || !selectedConversationId || !currentUser) return;
+    if (!newMessage.trim() || !selectedChatId || !currentUser) return;
 
-    addChatMessage(selectedConversationId, {
+    addChatMessage(selectedChatId, {
       id: `msg-${Date.now()}`,
       type: 'user',
       userId: currentUser.id,
@@ -111,11 +114,11 @@ export function FloatingChat() {
     );
 
     if (existingDM) {
-      setSelectedConversationId(existingDM.id);
+      setSelectedConversationId(`dm-${existingDM.id}`);
     } else {
       try {
         const newDM = await createDMConversation(participantId);
-        setSelectedConversationId(newDM.id);
+        setSelectedConversationId(`dm-${newDM.id}`);
       } catch (err) {
         console.error('Failed to create or navigate to DM', err);
       }
@@ -167,7 +170,7 @@ export function FloatingChat() {
       {isOpen && (
         <Card className={`fixed bottom-6 right-6 ${isExpanded ? 'w-[calc(100vw-3rem)] h-[calc(100vh-3rem)]' : 'w-[680px] h-[580px]'} shadow-2xl flex flex-row z-50 overflow-hidden transition-all duration-300 ease-in-out`}>
           {/* Conversations List - Left Side */}
-          <div className="w-[240px] border-r flex flex-col bg-muted/30">
+          <div className="w-[240px] border-r flex flex-col bg-muted/30 min-h-0 overflow-hidden">
             {/* Header */}
             <div className="px-4 py-3 border-b bg-background flex items-center justify-between">
               <div className="flex items-center gap-2">
@@ -217,7 +220,7 @@ export function FloatingChat() {
             </div>
 
             {/* Conversations */}
-            <ScrollArea className="flex-1">
+            <div className="flex-1 min-h-0 overflow-y-auto">
               <div className="py-2">
                 {conversations.map(conversation => {
                   const isSelected = conversation.id === selectedConversationId;
@@ -258,7 +261,7 @@ export function FloatingChat() {
                   );
                 })}
               </div>
-            </ScrollArea>
+            </div>
           </div>
 
           {/* Messages - Right Side */}
@@ -338,9 +341,9 @@ export function FloatingChat() {
                               <div className={`max-w-[75%] rounded-2xl px-4 py-2 bg-muted text-foreground ${msg.message === '[This message has been deleted]' ? 'italic opacity-60' : ''}`}>
                                 <p className="text-sm break-words">{msg.message}</p>
                               </div>
-                              {isLeader && msg.message !== '[This message has been deleted]' && selectedConversationId && (
-                                <button 
-                                  onClick={() => deleteChatMessage(selectedConversationId, msg.id)}
+                              {isLeader && msg.message !== '[This message has been deleted]' && selectedChatId && (
+                                <button
+                                  onClick={() => deleteChatMessage(selectedChatId, msg.id)}
                                   className="opacity-0 group-hover/msg:opacity-100 p-1 text-red-500 hover:bg-red-50 rounded transition-opacity"
                                   title="Delete message"
                                 >
@@ -350,9 +353,9 @@ export function FloatingChat() {
                             </div>
                           ) : (
                             <div className="flex items-center gap-2 w-full justify-end">
-                              {isLeader && msg.message !== '[This message has been deleted]' && selectedConversationId && (
-                                <button 
-                                  onClick={() => deleteChatMessage(selectedConversationId, msg.id)}
+                              {isLeader && msg.message !== '[This message has been deleted]' && selectedChatId && (
+                                <button
+                                  onClick={() => deleteChatMessage(selectedChatId, msg.id)}
                                   className="opacity-0 group-hover/msg:opacity-100 p-1 text-red-500 hover:bg-red-50 rounded transition-opacity"
                                   title="Delete message"
                                 >

--- a/frontend/src/app/contexts/app-context.tsx
+++ b/frontend/src/app/contexts/app-context.tsx
@@ -207,7 +207,7 @@ interface AppContextType {
   setCurrentGroup: (group: Group | null) => void;
   swipeEvents: SwipeEvent[];
   createSwipeEvent: (groupId: string, name: string, borough?: string, neighborhood?: string) => Promise<SwipeEvent>;
-  fetchSwipeEvents: (groupId: string) => Promise<void>;
+  fetchSwipeEvents: (groupId: string, signal?: AbortSignal) => Promise<void>;
   currentSwipeEvent: SwipeEvent | null;
   setCurrentSwipeEvent: (event: SwipeEvent | null) => void;
   swipes: Record<string, Swipe[]>; // eventId -> swipes
@@ -618,7 +618,8 @@ export function AppProvider({ children }: { children: ReactNode }) {
         
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         chats.forEach((chat: any) => {
-          newChatMessages[chat.id] = chat.messages || [];
+          const msgKey = chat.type === 'direct' ? `dm-${chat.id}` : chat.id;
+          newChatMessages[msgKey] = chat.messages || [];
           newMutedParticipants[chat.id] = chat.mutedParticipants || [];
           if (chat.type === 'direct') {
             dms.push({
@@ -1328,10 +1329,11 @@ export function AppProvider({ children }: { children: ReactNode }) {
     return newEvent;
   };
 
-  const fetchSwipeEvents = async (groupId: string) => {
+  const fetchSwipeEvents = useCallback(async (groupId: string, signal?: AbortSignal) => {
     try {
       const response = await fetch(apiUrl(`/api/groups/${groupId}/events/`), {
         credentials: 'include',
+        signal,
       });
       const data = await response.json();
       if (data.success) {
@@ -1357,9 +1359,10 @@ export function AppProvider({ children }: { children: ReactNode }) {
         setSwipeEvents(events);
       }
     } catch (error) {
+      if (error instanceof DOMException && error.name === 'AbortError') return;
       console.error('Failed to fetch swipe events:', error);
     }
-  };
+  }, []);
 
   const addSwipe = async (
     eventId: string,
@@ -1421,7 +1424,8 @@ export function AppProvider({ children }: { children: ReactNode }) {
   const addChatMessage = async (conversationId: string, message: ChatMessage) => {
     try {
       const csrftoken = getCookie('csrftoken') || '';
-      const response = await fetch(apiUrl(`/api/chat/${conversationId}/messages/`), {
+      const rawId = conversationId.startsWith('dm-') ? conversationId.slice(3) : conversationId;
+      const response = await fetch(apiUrl(`/api/chat/${rawId}/messages/`), {
         method: 'POST',
         credentials: 'include',
         headers: {
@@ -1473,7 +1477,8 @@ export function AppProvider({ children }: { children: ReactNode }) {
   const deleteChatMessage = async (conversationId: string, messageId: string) => {
     try {
       const csrftoken = getCookie('csrftoken') || '';
-      const response = await fetch(apiUrl(`/api/chat/${conversationId}/messages/${messageId}/`), {
+      const rawId = conversationId.startsWith('dm-') ? conversationId.slice(3) : conversationId;
+      const response = await fetch(apiUrl(`/api/chat/${rawId}/messages/${messageId}/`), {
         method: 'DELETE',
         credentials: 'include',
         headers: {
@@ -1525,7 +1530,7 @@ export function AppProvider({ children }: { children: ReactNode }) {
           lastMessageTime: chat.lastMessageTime || chat.created_at,
         };
         setDMConversations(prev => [...prev.filter(dm => dm.id !== chat.id), newDm]);
-        setChatMessages(prev => ({ ...prev, [chat.id]: chat.messages || [] }));
+        setChatMessages(prev => ({ ...prev, [`dm-${chat.id}`]: chat.messages || [] }));
         return newDm;
       }
     } catch (err) {

--- a/frontend/src/app/pages/group-detail-page.tsx
+++ b/frontend/src/app/pages/group-detail-page.tsx
@@ -87,9 +87,10 @@ export function GroupDetailPage() {
   );
 
   useEffect(() => {
-    if (groupId) {
-      fetchSwipeEvents(groupId);
-    }
+    if (!groupId) return;
+    const controller = new AbortController();
+    fetchSwipeEvents(groupId, controller.signal);
+    return () => controller.abort();
   }, [groupId, fetchSwipeEvents]);
 
   useEffect(() => {
@@ -453,41 +454,45 @@ export function GroupDetailPage() {
 
         {/* Action Buttons Grid */}
         <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-4">
-          {/* Create New Swipe Event */}
-          <Card
-            className="cursor-pointer hover:shadow-lg transition-shadow bg-gradient-to-br from-purple-500 to-indigo-500 text-white border-0"
-            onClick={handleCreateEvent}
-          >
-            <CardHeader className="pb-6">
-              <div className="w-12 h-12 bg-white/20 rounded-xl flex items-center justify-center mb-3">
-                <Plus className="w-6 h-6" />
-              </div>
-              <CardTitle className="mb-2">
-                Start Swipe Session
-              </CardTitle>
-              <CardDescription className="text-purple-100">
-                Quickly swipe on restaurants now
-              </CardDescription>
-            </CardHeader>
-          </Card>
+          {/* Create New Swipe Event - leaders only */}
+          {isLeader && (
+            <Card
+              className="cursor-pointer hover:shadow-lg transition-shadow bg-gradient-to-br from-purple-500 to-indigo-500 text-white border-0"
+              onClick={handleCreateEvent}
+            >
+              <CardHeader className="pb-6">
+                <div className="w-12 h-12 bg-white/20 rounded-xl flex items-center justify-center mb-3">
+                  <Plus className="w-6 h-6" />
+                </div>
+                <CardTitle className="mb-2">
+                  Start Swipe Session
+                </CardTitle>
+                <CardDescription className="text-purple-100">
+                  Quickly swipe on restaurants now
+                </CardDescription>
+              </CardHeader>
+            </Card>
+          )}
 
-          {/* NEW: Plan Reservation Button */}
-          <Card
-            className="cursor-pointer hover:shadow-lg transition-shadow bg-gradient-to-br from-pink-500 to-purple-600 text-white border-0"
-            onClick={handlePlanReservation}
-          >
-            <CardHeader className="pb-6">
-              <div className="w-12 h-12 bg-white/20 rounded-xl flex items-center justify-center mb-3">
-                <CalendarDays className="w-6 h-6" />
-              </div>
-              <CardTitle className="mb-2">
-                Plan Reservation
-              </CardTitle>
-              <CardDescription className="text-pink-100">
-                Set date, location & specific plans
-              </CardDescription>
-            </CardHeader>
-          </Card>
+          {/* Plan Reservation Button - leaders only */}
+          {isLeader && (
+            <Card
+              className="cursor-pointer hover:shadow-lg transition-shadow bg-gradient-to-br from-pink-500 to-purple-600 text-white border-0"
+              onClick={handlePlanReservation}
+            >
+              <CardHeader className="pb-6">
+                <div className="w-12 h-12 bg-white/20 rounded-xl flex items-center justify-center mb-3">
+                  <CalendarDays className="w-6 h-6" />
+                </div>
+                <CardTitle className="mb-2">
+                  Plan Reservation
+                </CardTitle>
+                <CardDescription className="text-pink-100">
+                  Set date, location & specific plans
+                </CardDescription>
+              </CardHeader>
+            </Card>
+          )}
 
           {/* Group Constraints Card */}
           <Dialog open={showConstraintsDialog} onOpenChange={setShowConstraintsDialog}>


### PR DESCRIPTION

- Replace ScrollArea with native overflow-y-auto divs in chat-sidebar and floating-chat so the conversations list and message area scroll correctly
- Prefix chatMessages keys for DMs with 'dm-' to prevent collision with group IDs (Group.id and Chat.id are from separate DB sequences and can clash)
- Namespace floating-chat conversation list IDs ('group-{id}', 'dm-{id}') so selecting a DM no longer highlights the group with the same numeric ID
- Fix handleStartDM to set selectedConversationId with 'dm-' prefix so opening a DM via openUserDM correctly resolves the conversation
- Strip 'dm-' prefix in addChatMessage/deleteChatMessage before API calls since the backend expects raw numeric IDs
- Restrict Start Swipe Session and Plan Reservation cards to leaders only