### PR TITLE
Chat group sec swipe

### DIFF
--- a/frontend/src/app/components/floating-chat.tsx
+++ b/frontend/src/app/components/floating-chat.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef, useEffect, useMemo, useCallback } from 'react';
+import { useState, useRef, useEffect, useCallback, useMemo } from 'react';
 import { MessageCircle, X, Send, Plus, Users, Trash2, Maximize2, Minimize2 } from 'lucide-react';
 import { Button } from '@/app/components/ui/button';
 import { Card } from '@/app/components/ui/card';
@@ -35,49 +35,52 @@ export function FloatingChat() {
   const [showNewDMDialog, setShowNewDMDialog] = useState(false);
   const messagesEndRef = useRef<HTMLDivElement>(null);
 
-  // Build conversation list
-  const conversations: Conversation[] = [
-    ...groups.map(g => ({
-      id: `group-${g.id}`,
-      chatId: g.id,
-      type: 'group' as ConversationType,
-      name: g.name,
-      isGroup: true,
-      lastMessage: chatMessages[g.id]?.slice(-1)[0]?.message,
-      lastMessageTime: chatMessages[g.id]?.slice(-1)[0]?.timestamp
-    })),
-    ...dmConversations.map(dm => {
-      const otherParticipantName = dm.participantNames.find(name => name !== currentUser?.name) || 'Unknown';
-      return {
-        id: `dm-${dm.id}`,
-        chatId: `dm-${dm.id}`,
-        type: 'dm' as ConversationType,
-        name: otherParticipantName,
-        isGroup: false,
-        lastMessage: chatMessages[`dm-${dm.id}`]?.slice(-1)[0]?.message,
-        lastMessageTime: dm.lastMessageTime
-      };
-    })
-  ];
+  // Build and sort conversation list
+  const conversations = useMemo((): Conversation[] => {
+    const list: Conversation[] = [
+      ...groups.map(g => ({
+        id: `group-${g.id}`,
+        chatId: g.id,
+        type: 'group' as ConversationType,
+        name: g.name,
+        isGroup: true,
+        lastMessage: chatMessages[g.id]?.slice(-1)[0]?.message,
+        lastMessageTime: chatMessages[g.id]?.slice(-1)[0]?.timestamp
+      })),
+      ...dmConversations.map(dm => {
+        const otherParticipantName = dm.participantNames.find(name => name !== currentUser?.name) || 'Unknown';
+        return {
+          id: `dm-${dm.id}`,
+          chatId: `dm-${dm.id}`,
+          type: 'dm' as ConversationType,
+          name: otherParticipantName,
+          isGroup: false,
+          lastMessage: chatMessages[`dm-${dm.id}`]?.slice(-1)[0]?.message,
+          lastMessageTime: dm.lastMessageTime
+        };
+      })
+    ];
+    list.sort((a, b) => (b.lastMessageTime || '0').localeCompare(a.lastMessageTime || '0'));
+    return list;
+  }, [groups, dmConversations, chatMessages, currentUser?.name]);
 
-  // Sort conversations by last message time
-  conversations.sort((a, b) => {
-    const aTime = a.lastMessageTime || '0';
-    const bTime = b.lastMessageTime || '0';
-    return bTime.localeCompare(aTime);
-  });
+  // Derive the active conversation ID: use explicit selection if valid, else fall back to first
+  const activeConversationId = useMemo(
+    () => (selectedConversationId && conversations.some(c => c.id === selectedConversationId))
+      ? selectedConversationId
+      : (conversations[0]?.id ?? ''),
+    [conversations, selectedConversationId]
+  );
 
-  // Set initial conversation when data loads
-  useEffect(() => {
-    if (conversations.length > 0 && !selectedConversationId) {
-      // eslint-disable-next-line react-hooks/set-state-in-effect
-      setSelectedConversationId(conversations[0].id);
-    }
-  }, [conversations.length, selectedConversationId]); // eslint-disable-line react-hooks/exhaustive-deps
-
-  const selectedConversation = conversations.find(c => c.id === selectedConversationId);
+  const selectedConversation = useMemo(
+    () => conversations.find(c => c.id === activeConversationId),
+    [conversations, activeConversationId]
+  );
   const selectedChatId = selectedConversation?.chatId ?? '';
-  const messages = useMemo(() => selectedChatId ? chatMessages[selectedChatId] || [] : [], [selectedChatId, chatMessages]);
+  const messages = useMemo(
+    () => (selectedChatId ? chatMessages[selectedChatId] || [] : []),
+    [selectedChatId, chatMessages]
+  );
   const isLeader = selectedConversation?.isGroup ? groups.find(g => g.id === selectedChatId)?.members.find(m => m.userId === currentUser?.id)?.isLeader : false;
 
   // Auto-scroll to bottom when messages change
@@ -85,7 +88,7 @@ export function FloatingChat() {
     messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
   }, [messages]);
 
-  const handleSendMessage = () => {
+  const handleSendMessage = useCallback(() => {
     if (!newMessage.trim() || !selectedChatId || !currentUser) return;
 
     addChatMessage(selectedChatId, {
@@ -98,7 +101,7 @@ export function FloatingChat() {
     });
 
     setNewMessage('');
-  };
+  }, [newMessage, selectedChatId, currentUser, addChatMessage]);
 
   const handleKeyPress = (e: React.KeyboardEvent) => {
     if (e.key === 'Enter' && !e.shiftKey) {
@@ -223,7 +226,7 @@ export function FloatingChat() {
             <div className="flex-1 min-h-0 overflow-y-auto">
               <div className="py-2">
                 {conversations.map(conversation => {
-                  const isSelected = conversation.id === selectedConversationId;
+                  const isSelected = conversation.id === activeConversationId;
                   return (
                     <button
                       key={conversation.id}

--- a/frontend/src/app/pages/__tests__/group-detail-page.test.tsx
+++ b/frontend/src/app/pages/__tests__/group-detail-page.test.tsx
@@ -78,7 +78,7 @@ describe('GroupDetailPage Synchronization', () => {
     // Give the layout time to mount and useEffect to fire natively
     await waitFor(() => {
       // Expect that `fetchSwipeEvents('group1')` was executed at least once safely
-      expect(mockFetchSwipeEvents).toHaveBeenCalledWith('group1');
+      expect(mockFetchSwipeEvents).toHaveBeenCalledWith('group1', expect.any(AbortSignal));
       expect(mockFetchSwipeEvents).toHaveBeenCalledTimes(1);
     });
   });


### PR DESCRIPTION
This pull request refactors the `FloatingChat` component to improve performance and simplify conversation selection logic. The most important changes are the use of `useMemo` and `useCallback` hooks to optimize computations and event handlers, and a more robust approach to determining the active conversation. Additionally, a test has been updated to match a new function signature.

**FloatingChat performance and logic improvements:**

* The conversation list is now built and sorted inside a `useMemo` hook, ensuring the computation only runs when its dependencies change, which improves performance. [[1]](diffhunk://#diff-2b87a7648e093f0ff63ecd1e01473297a43234eae9b339cae7b824eec5709865L38-R40) [[2]](diffhunk://#diff-2b87a7648e093f0ff63ecd1e01473297a43234eae9b339cae7b824eec5709865R63-R91)
* The logic for determining the active conversation has been moved to a `useMemo` hook (`activeConversationId`), which falls back to the first available conversation if no valid selection exists. This replaces the previous `useEffect`-based approach and simplifies state management.
* The selected conversation and its messages are now derived using `useMemo` for better performance and to avoid unnecessary renders.
* The message sending handler (`handleSendMessage`) is wrapped in `useCallback` for referential stability.
* The UI now uses `activeConversationId` instead of `selectedConversationId` to determine which conversation is selected, ensuring consistency with the new logic.

**Test update:**

* The `GroupDetailPage Synchronization` test now expects `fetchSwipeEvents` to be called with an `AbortSignal` as the second argument, reflecting a change in the function signature.