### PR TITLE
feat: lazy-load venue photos from Google Places API

### DIFF
--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -152,6 +152,9 @@ else:
     }
 
 
+# Google Places API
+GOOGLE_PLACES_API_KEY = os.environ.get("GOOGLE_PLACES_API_KEY", "")
+
 # Password validation
 # https://docs.djangoproject.com/en/4.2/ref/settings/#auth-password-validators
 

--- a/backend/groups/tests.py
+++ b/backend/groups/tests.py
@@ -850,6 +850,29 @@ class SwipeEventAPITests(TestCase):
         self.assertIn("Pizza Place", venue_names)
         self.assertNotIn("Sushi Spot", venue_names)
 
+    def test_venues_without_place_id_and_photos_are_excluded(self):
+        """Venues with no google_place_id and no photos must not appear in swipe results."""
+        Venue.objects.create(
+            name="Ghost Venue",
+            sanitation_grade="A",
+            is_active=True,
+            # no google_place_id, no VenuePhoto
+        )
+
+        event = SwipeEvent.objects.create(
+            group=self.group,
+            name="Exclusion Test",
+            created_by=self.leader,
+        )
+
+        self.client.login(email="leader@nyu.edu", password="pass123")
+        response = self.client.get(
+            f"/api/groups/{self.group.id}/events/{event.id}/venues/"
+        )
+        data = response.json()
+        venue_names = [v["name"] for v in data["venues"]]
+        self.assertNotIn("Ghost Venue", venue_names)
+
 
 class GroupManagementAPITests(TestCase):
     """Tests for group CRUD, invite, remove, make leader, leave endpoints."""

--- a/backend/groups/tests.py
+++ b/backend/groups/tests.py
@@ -3,7 +3,7 @@ from django.contrib.auth import get_user_model
 import json
 
 from .models import Group, GroupMembership, SwipeEvent, Swipe, GroupInvitation
-from venues.models import Venue
+from venues.models import Venue, VenuePhoto
 from accounts.models import UserPreference
 
 User = get_user_model()
@@ -228,15 +228,43 @@ class SwipeEventAPITests(TestCase):
             user=self.member2, group=self.group, role=GroupMembership.Role.MEMBER
         )
 
-        # Create venues
+        # Create venues with google_place_id and a pre-cached photo so they pass
+        # the "has place ID or photo" filter and bulk_prefetch_photos skips API calls.
         self.venue1 = Venue.objects.create(
-            name="Pizza Place", sanitation_grade="A", is_active=True
+            name="Pizza Place",
+            sanitation_grade="A",
+            is_active=True,
+            google_place_id="test_place_id_1",
+        )
+        VenuePhoto.objects.create(
+            venue=self.venue1,
+            image_url="https://example.com/pizza.jpg",
+            source="google_places",
+            is_primary=True,
         )
         self.venue2 = Venue.objects.create(
-            name="Sushi Spot", sanitation_grade="A", is_active=True
+            name="Sushi Spot",
+            sanitation_grade="A",
+            is_active=True,
+            google_place_id="test_place_id_2",
+        )
+        VenuePhoto.objects.create(
+            venue=self.venue2,
+            image_url="https://example.com/sushi.jpg",
+            source="google_places",
+            is_primary=True,
         )
         self.venue3 = Venue.objects.create(
-            name="Burger Joint", sanitation_grade="B", is_active=True
+            name="Burger Joint",
+            sanitation_grade="B",
+            is_active=True,
+            google_place_id="test_place_id_3",
+        )
+        VenuePhoto.objects.create(
+            venue=self.venue3,
+            image_url="https://example.com/burger.jpg",
+            source="google_places",
+            is_primary=True,
         )
 
     def test_create_event_as_leader(self):

--- a/backend/groups/views.py
+++ b/backend/groups/views.py
@@ -1078,8 +1078,9 @@ def api_swipe_event_venues(request, group_id, event_id):
             .order_by(models.F("google_rating").desc(nulls_last=True))[:20]
         )
 
-        # Fetch missing Google Places photos in parallel before serializing,
-        # then refresh the photos prefetch cache so _venue_to_swipe_json stays side-effect free.
+        # Fetch missing Google Places photos in parallel (bulk_prefetch_photos) before
+        # serializing, then refresh the prefetch cache so _venue_to_swipe_json only reads
+        # already-loaded data and never performs API calls or DB writes itself.
         from venues.google_places import bulk_prefetch_photos
 
         venues_list = list(venues_qs)

--- a/backend/groups/views.py
+++ b/backend/groups/views.py
@@ -1061,10 +1061,12 @@ def api_swipe_event_venues(request, group_id, event_id):
         venues_qs = venues_qs.exclude(id__in=swiped_venue_ids)
 
         # Only show venues that have a photo already or a Google Place ID to fetch one from
-        has_place_id = (
-            models.Q(google_place_id__isnull=False) & ~models.Q(google_place_id="")
+        has_place_id = models.Q(google_place_id__isnull=False) & ~models.Q(
+            google_place_id=""
         )
-        has_photos = models.Exists(VenuePhoto.objects.filter(venue=models.OuterRef("pk")))
+        has_photos = models.Exists(
+            VenuePhoto.objects.filter(venue=models.OuterRef("pk"))
+        )
         venues_qs = venues_qs.filter(has_place_id | has_photos)
 
         # Order by rating (best first), limit to 20
@@ -1079,6 +1081,7 @@ def api_swipe_event_venues(request, group_id, event_id):
         # Fetch missing Google Places photos in parallel before serializing,
         # then refresh the photos prefetch cache so _venue_to_swipe_json stays side-effect free.
         from venues.google_places import bulk_prefetch_photos
+
         venues_list = list(venues_qs)
         bulk_prefetch_photos(venues_list)
         prefetch_related_objects(venues_list, "photos")

--- a/backend/groups/views.py
+++ b/backend/groups/views.py
@@ -5,14 +5,14 @@ from django.http import JsonResponse
 from django.views.decorators.csrf import csrf_exempt
 from django.contrib.auth import get_user_model
 from django.db import transaction, models
-from django.db.models import Count
+from django.db.models import Count, prefetch_related_objects
 from django.core.exceptions import ValidationError
 from django.core.validators import validate_email
 from django.utils import timezone
 
 from .models import Group, GroupMembership, SwipeEvent, Swipe, GroupInvitation
 from accounts.models import UserPreference
-from venues.models import Venue
+from venues.models import Venue, VenuePhoto
 from chat.models import Chat, ChatMember as ChatRoomMember, Message
 
 logger = logging.getLogger(__name__)
@@ -819,13 +819,7 @@ def _venue_to_swipe_json(venue):
     """
     # Use prefetched cache via .all() instead of queryset ops that bypass it
     all_photos = sorted(venue.photos.all(), key=lambda p: not p.is_primary)
-
-    if not all_photos and venue.google_place_id:
-        from venues.google_places import fetch_and_cache_primary_photo
-        fetched = fetch_and_cache_primary_photo(venue)
-        photos = [fetched] if fetched else []
-    else:
-        photos = [p.image_url for p in all_photos[:3]]
+    photos = [p.image_url for p in all_photos[:3]]
     dietary_tags = [t.name for t in venue.dietary_tags.all()]
     food_type_tags = [t.name for t in venue.food_type_tags.all()]
 
@@ -1066,10 +1060,12 @@ def api_swipe_event_venues(request, group_id, event_id):
         ).values_list("venue_id", flat=True)
         venues_qs = venues_qs.exclude(id__in=swiped_venue_ids)
 
-        # Only show venues that have a Google Place ID (guarantees a photo can be fetched)
-        venues_qs = venues_qs.filter(
-            google_place_id__isnull=False
-        ).exclude(google_place_id="")
+        # Only show venues that have a photo already or a Google Place ID to fetch one from
+        has_place_id = (
+            models.Q(google_place_id__isnull=False) & ~models.Q(google_place_id="")
+        )
+        has_photos = models.Exists(VenuePhoto.objects.filter(venue=models.OuterRef("pk")))
+        venues_qs = venues_qs.filter(has_place_id | has_photos)
 
         # Order by rating (best first), limit to 20
         venues_qs = (
@@ -1080,7 +1076,14 @@ def api_swipe_event_venues(request, group_id, event_id):
             .order_by(models.F("google_rating").desc(nulls_last=True))[:20]
         )
 
-        venues_data = [_venue_to_swipe_json(v) for v in venues_qs]
+        # Fetch missing Google Places photos in parallel before serializing,
+        # then refresh the photos prefetch cache so _venue_to_swipe_json stays side-effect free.
+        from venues.google_places import bulk_prefetch_photos
+        venues_list = list(venues_qs)
+        bulk_prefetch_photos(venues_list)
+        prefetch_related_objects(venues_list, "photos")
+
+        venues_data = [_venue_to_swipe_json(v) for v in venues_list]
         return JsonResponse({"success": True, "venues": venues_data})
 
     except Group.DoesNotExist:

--- a/backend/groups/views.py
+++ b/backend/groups/views.py
@@ -1066,6 +1066,11 @@ def api_swipe_event_venues(request, group_id, event_id):
         ).values_list("venue_id", flat=True)
         venues_qs = venues_qs.exclude(id__in=swiped_venue_ids)
 
+        # Only show venues that have a Google Place ID (guarantees a photo can be fetched)
+        venues_qs = venues_qs.filter(
+            google_place_id__isnull=False
+        ).exclude(google_place_id="")
+
         # Order by rating (best first), limit to 20
         venues_qs = (
             venues_qs.select_related("cuisine_type")

--- a/backend/groups/views.py
+++ b/backend/groups/views.py
@@ -819,7 +819,13 @@ def _venue_to_swipe_json(venue):
     """
     # Use prefetched cache via .all() instead of queryset ops that bypass it
     all_photos = sorted(venue.photos.all(), key=lambda p: not p.is_primary)
-    photos = [p.image_url for p in all_photos[:3]]
+
+    if not all_photos and venue.google_place_id:
+        from venues.google_places import fetch_and_cache_primary_photo
+        fetched = fetch_and_cache_primary_photo(venue)
+        photos = [fetched] if fetched else []
+    else:
+        photos = [p.image_url for p in all_photos[:3]]
     dietary_tags = [t.name for t in venue.dietary_tags.all()]
     food_type_tags = [t.name for t in venue.food_type_tags.all()]
 

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -4,3 +4,4 @@ gunicorn==22.0.0
 python-dotenv==1.0.1
 certifi==2026.2.25
 psycopg2-binary==2.9.10
+requests==2.32.3

--- a/backend/venues/google_places.py
+++ b/backend/venues/google_places.py
@@ -1,0 +1,82 @@
+import logging
+import os
+
+import requests
+
+logger = logging.getLogger(__name__)
+
+_API_KEY = os.environ.get("GOOGLE_PLACES_API_KEY", "")
+
+_PLACES_DETAIL_URL = "https://places.googleapis.com/v1/places/{place_id}?fields=photos&key={key}"
+_PLACES_MEDIA_URL = "https://places.googleapis.com/v1/{photo_name}/media?maxWidthPx=800&key={key}"
+
+
+def fetch_and_cache_primary_photo(venue):
+    """
+    Returns the primary photo URL for a venue, fetching from Google Places API if not yet cached.
+
+    On first call: hits the API, saves the URL to VenuePhoto (source='google_places'), returns URL.
+    On subsequent calls: returns the cached URL from VenuePhoto immediately.
+    Returns None if the venue has no google_place_id, the key is missing, or the API call fails.
+    """
+    from venues.models import VenuePhoto  # local import to avoid circular dependency
+
+    if not venue.google_place_id or not _API_KEY:
+        return None
+
+    # Check DB cache first
+    cached = (
+        VenuePhoto.objects.filter(venue=venue, source="google_places", is_primary=True)
+        .values_list("image_url", flat=True)
+        .first()
+    )
+    if cached:
+        return cached
+
+    try:
+        # Step 1: get photo resource names for this place
+        detail_resp = requests.get(
+            _PLACES_DETAIL_URL.format(place_id=venue.google_place_id, key=_API_KEY),
+            timeout=5,
+        )
+        detail_resp.raise_for_status()
+        photos = detail_resp.json().get("photos", [])
+        if not photos:
+            return None
+
+        photo_name = photos[0]["name"]  # e.g. "places/ChIJ.../photos/AUac..."
+
+        # Step 2: resolve the media URL to its CDN redirect (avoids embedding API key in stored URL)
+        media_resp = requests.get(
+            _PLACES_MEDIA_URL.format(photo_name=photo_name, key=_API_KEY),
+            timeout=5,
+            allow_redirects=False,
+        )
+
+        if media_resp.status_code in (301, 302, 303, 307, 308):
+            image_url = media_resp.headers.get("Location")
+        elif media_resp.status_code == 200:
+            # API returned the image directly — fall back to storing the media URL
+            image_url = _PLACES_MEDIA_URL.format(photo_name=photo_name, key=_API_KEY)
+        else:
+            logger.warning(
+                "Google Places media request returned %s for venue %s",
+                media_resp.status_code,
+                venue.id,
+            )
+            return None
+
+        if not image_url:
+            return None
+
+        VenuePhoto.objects.create(
+            venue=venue,
+            image_url=image_url,
+            source="google_places",
+            is_primary=True,
+        )
+        return image_url
+
+    except Exception:
+        logger.exception("Failed to fetch Google Places photo for venue %s", venue.id)
+        return None

--- a/backend/venues/google_places.py
+++ b/backend/venues/google_places.py
@@ -1,27 +1,32 @@
 import logging
-import os
+from concurrent.futures import ThreadPoolExecutor
 
 import requests
+from django.conf import settings
 
 logger = logging.getLogger(__name__)
 
-_API_KEY = os.environ.get("GOOGLE_PLACES_API_KEY", "")
-
-_PLACES_DETAIL_URL = "https://places.googleapis.com/v1/places/{place_id}?fields=photos&key={key}"
-_PLACES_MEDIA_URL = "https://places.googleapis.com/v1/{photo_name}/media?maxWidthPx=800&key={key}"
+_PLACES_DETAIL_URL = (
+    "https://places.googleapis.com/v1/places/{place_id}?fields=photos&key={key}"
+)
+_PLACES_MEDIA_URL = (
+    "https://places.googleapis.com/v1/{photo_name}/media?maxWidthPx=800&key={key}"
+)
 
 
 def fetch_and_cache_primary_photo(venue):
     """
     Returns the primary photo URL for a venue, fetching from Google Places API if not yet cached.
 
-    On first call: hits the API, saves the URL to VenuePhoto (source='google_places'), returns URL.
-    On subsequent calls: returns the cached URL from VenuePhoto immediately.
+    On first call: hits the API, resolves the CDN redirect URL (no API key stored),
+    saves to VenuePhoto, and returns the URL.
+    On subsequent calls: returns the cached URL from VenuePhoto with no API call.
     Returns None if the venue has no google_place_id, the key is missing, or the API call fails.
     """
     from venues.models import VenuePhoto  # local import to avoid circular dependency
 
-    if not venue.google_place_id or not _API_KEY:
+    api_key = getattr(settings, "GOOGLE_PLACES_API_KEY", "")
+    if not venue.google_place_id or not api_key:
         return None
 
     # Check DB cache first
@@ -36,7 +41,7 @@ def fetch_and_cache_primary_photo(venue):
     try:
         # Step 1: get photo resource names for this place
         detail_resp = requests.get(
-            _PLACES_DETAIL_URL.format(place_id=venue.google_place_id, key=_API_KEY),
+            _PLACES_DETAIL_URL.format(place_id=venue.google_place_id, key=api_key),
             timeout=5,
         )
         detail_resp.raise_for_status()
@@ -46,21 +51,21 @@ def fetch_and_cache_primary_photo(venue):
 
         photo_name = photos[0]["name"]  # e.g. "places/ChIJ.../photos/AUac..."
 
-        # Step 2: resolve the media URL to its CDN redirect (avoids embedding API key in stored URL)
+        # Step 2: follow the redirect to get the stable CDN URL (lh3.googleusercontent.com)
+        # so that the API key is never stored in the database or returned to clients.
         media_resp = requests.get(
-            _PLACES_MEDIA_URL.format(photo_name=photo_name, key=_API_KEY),
+            _PLACES_MEDIA_URL.format(photo_name=photo_name, key=api_key),
             timeout=5,
             allow_redirects=False,
         )
 
         if media_resp.status_code in (301, 302, 303, 307, 308):
             image_url = media_resp.headers.get("Location")
-        elif media_resp.status_code == 200:
-            # API returned the image directly — fall back to storing the media URL
-            image_url = _PLACES_MEDIA_URL.format(photo_name=photo_name, key=_API_KEY)
         else:
+            # Google Places normally redirects; if it doesn't, skip caching to
+            # avoid storing a URL that contains the API key.
             logger.warning(
-                "Google Places media request returned %s for venue %s",
+                "Google Places media request returned unexpected status %s for venue %s — skipping",
                 media_resp.status_code,
                 venue.id,
             )
@@ -69,14 +74,31 @@ def fetch_and_cache_primary_photo(venue):
         if not image_url:
             return None
 
-        VenuePhoto.objects.create(
+        # get_or_create prevents duplicate rows under concurrent requests
+        photo, _ = VenuePhoto.objects.get_or_create(
             venue=venue,
-            image_url=image_url,
             source="google_places",
             is_primary=True,
+            defaults={"image_url": image_url},
         )
-        return image_url
+        return photo.image_url
 
     except Exception:
         logger.exception("Failed to fetch Google Places photo for venue %s", venue.id)
         return None
+
+
+def bulk_prefetch_photos(venues, max_workers=5):
+    """
+    Ensures all venues in the list have a cached primary Google Places photo.
+    Fetches missing photos in parallel so the serialization loop stays side-effect free.
+    Expects venues to have already had their 'photos' relation prefetched.
+    """
+    needs_fetch = [
+        v for v in venues
+        if v.google_place_id and not list(v.photos.all())
+    ]
+    if not needs_fetch:
+        return
+    with ThreadPoolExecutor(max_workers=min(len(needs_fetch), max_workers)) as executor:
+        executor.map(fetch_and_cache_primary_photo, needs_fetch)

--- a/backend/venues/google_places.py
+++ b/backend/venues/google_places.py
@@ -3,23 +3,22 @@ from concurrent.futures import ThreadPoolExecutor
 
 import requests
 from django.conf import settings
+from django.db import close_old_connections
 
 logger = logging.getLogger(__name__)
 
-_PLACES_DETAIL_URL = (
-    "https://places.googleapis.com/v1/places/{place_id}?fields=photos&key={key}"
-)
-_PLACES_MEDIA_URL = (
-    "https://places.googleapis.com/v1/{photo_name}/media?maxWidthPx=800&key={key}"
-)
+# Key is sent via request header so it never appears in URLs (and therefore never
+# leaks into exception messages, access logs, or referrer headers).
+_PLACES_DETAIL_URL = "https://places.googleapis.com/v1/places/{place_id}?fields=photos"
+_PLACES_MEDIA_URL = "https://places.googleapis.com/v1/{photo_name}/media?maxWidthPx=800"
 
 
 def fetch_and_cache_primary_photo(venue):
     """
     Returns the primary photo URL for a venue, fetching from Google Places API if not yet cached.
 
-    On first call: hits the API, resolves the CDN redirect URL (no API key stored),
-    saves to VenuePhoto, and returns the URL.
+    On first call: hits the API, resolves the CDN redirect URL (API key sent via header,
+    never stored), saves to VenuePhoto, and returns the URL.
     On subsequent calls: returns the cached URL from VenuePhoto with no API call.
     Returns None if the venue has no google_place_id, the key is missing, or the API call fails.
     """
@@ -38,10 +37,13 @@ def fetch_and_cache_primary_photo(venue):
     if cached:
         return cached
 
+    headers = {"X-Goog-Api-Key": api_key}
+
     try:
         # Step 1: get photo resource names for this place
         detail_resp = requests.get(
-            _PLACES_DETAIL_URL.format(place_id=venue.google_place_id, key=api_key),
+            _PLACES_DETAIL_URL.format(place_id=venue.google_place_id),
+            headers=headers,
             timeout=5,
         )
         detail_resp.raise_for_status()
@@ -54,7 +56,8 @@ def fetch_and_cache_primary_photo(venue):
         # Step 2: follow the redirect to get the stable CDN URL (lh3.googleusercontent.com)
         # so that the API key is never stored in the database or returned to clients.
         media_resp = requests.get(
-            _PLACES_MEDIA_URL.format(photo_name=photo_name, key=api_key),
+            _PLACES_MEDIA_URL.format(photo_name=photo_name),
+            headers=headers,
             timeout=5,
             allow_redirects=False,
         )
@@ -74,7 +77,8 @@ def fetch_and_cache_primary_photo(venue):
         if not image_url:
             return None
 
-        # get_or_create prevents duplicate rows under concurrent requests
+        # get_or_create is safe against duplicate inserts because VenuePhoto has a
+        # DB-level UniqueConstraint on (venue, source) for is_primary=True rows.
         photo, _ = VenuePhoto.objects.get_or_create(
             venue=venue,
             source="google_places",
@@ -88,14 +92,23 @@ def fetch_and_cache_primary_photo(venue):
         return None
 
 
+def _fetch_with_connection_cleanup(venue):
+    """Wrapper used by bulk_prefetch_photos to ensure each thread releases its DB connection."""
+    try:
+        return fetch_and_cache_primary_photo(venue)
+    finally:
+        close_old_connections()
+
+
 def bulk_prefetch_photos(venues, max_workers=5):
     """
     Ensures all venues in the list have a cached primary Google Places photo.
     Fetches missing photos in parallel so the serialization loop stays side-effect free.
     Expects venues to have already had their 'photos' relation prefetched.
+    Each worker thread calls close_old_connections() on exit to prevent DB connection leaks.
     """
     needs_fetch = [v for v in venues if v.google_place_id and not list(v.photos.all())]
     if not needs_fetch:
         return
     with ThreadPoolExecutor(max_workers=min(len(needs_fetch), max_workers)) as executor:
-        executor.map(fetch_and_cache_primary_photo, needs_fetch)
+        executor.map(_fetch_with_connection_cleanup, needs_fetch)

--- a/backend/venues/google_places.py
+++ b/backend/venues/google_places.py
@@ -94,10 +94,7 @@ def bulk_prefetch_photos(venues, max_workers=5):
     Fetches missing photos in parallel so the serialization loop stays side-effect free.
     Expects venues to have already had their 'photos' relation prefetched.
     """
-    needs_fetch = [
-        v for v in venues
-        if v.google_place_id and not list(v.photos.all())
-    ]
+    needs_fetch = [v for v in venues if v.google_place_id and not list(v.photos.all())]
     if not needs_fetch:
         return
     with ThreadPoolExecutor(max_workers=min(len(needs_fetch), max_workers)) as executor:

--- a/backend/venues/migrations/0004_venuephoto_unique_primary_photo_per_source.py
+++ b/backend/venues/migrations/0004_venuephoto_unique_primary_photo_per_source.py
@@ -1,0 +1,19 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("venues", "0003_add_venue_claim"),
+    ]
+
+    operations = [
+        migrations.AddConstraint(
+            model_name="venuephoto",
+            constraint=models.UniqueConstraint(
+                condition=models.Q(is_primary=True),
+                fields=["venue", "source"],
+                name="unique_primary_photo_per_source",
+            ),
+        ),
+    ]

--- a/backend/venues/models.py
+++ b/backend/venues/models.py
@@ -188,6 +188,17 @@ class VenuePhoto(models.Model):
     )
     created_at = models.DateTimeField(auto_now_add=True)
 
+    class Meta:
+        constraints = [
+            # Enforces at DB level that each venue has at most one primary photo per source,
+            # making get_or_create in fetch_and_cache_primary_photo race-safe.
+            models.UniqueConstraint(
+                fields=["venue", "source"],
+                condition=models.Q(is_primary=True),
+                name="unique_primary_photo_per_source",
+            )
+        ]
+
     def __str__(self):
         return f"{self.venue.name} — {'primary' if self.is_primary else 'photo'}"
 

--- a/backend/venues/tests.py
+++ b/backend/venues/tests.py
@@ -128,7 +128,9 @@ class GooglePlacesPhotoTest(TestCase):
         resp.raise_for_status = MagicMock()
         return resp
 
-    def _make_media_response(self, location="https://lh3.googleusercontent.com/places/photo"):
+    def _make_media_response(
+        self, location="https://lh3.googleusercontent.com/places/photo"
+    ):
         resp = MagicMock()
         resp.status_code = 302
         resp.headers = {"Location": location}
@@ -143,6 +145,7 @@ class GooglePlacesPhotoTest(TestCase):
         ]
 
         from venues.google_places import fetch_and_cache_primary_photo
+
         result = fetch_and_cache_primary_photo(self.venue)
 
         self.assertEqual(result, cdn_url)
@@ -162,6 +165,7 @@ class GooglePlacesPhotoTest(TestCase):
         )
 
         from venues.google_places import fetch_and_cache_primary_photo
+
         result = fetch_and_cache_primary_photo(self.venue)
 
         self.assertEqual(result, cdn_url)
@@ -172,6 +176,7 @@ class GooglePlacesPhotoTest(TestCase):
         mock_get.side_effect = Exception("network error")
 
         from venues.google_places import fetch_and_cache_primary_photo
+
         result = fetch_and_cache_primary_photo(self.venue)
 
         self.assertIsNone(result)
@@ -187,6 +192,7 @@ class GooglePlacesPhotoTest(TestCase):
         mock_get.side_effect = [detail_resp, media_resp]
 
         from venues.google_places import fetch_and_cache_primary_photo
+
         result = fetch_and_cache_primary_photo(self.venue)
 
         self.assertIsNone(result)
@@ -196,6 +202,7 @@ class GooglePlacesPhotoTest(TestCase):
         venue = Venue.objects.create(name="No Place ID Venue")
 
         from venues.google_places import fetch_and_cache_primary_photo
+
         result = fetch_and_cache_primary_photo(venue)
 
         self.assertIsNone(result)

--- a/backend/venues/tests.py
+++ b/backend/venues/tests.py
@@ -1,6 +1,9 @@
 # venues/tests.py
-from django.test import TestCase
+from unittest.mock import MagicMock, patch
+
+from django.test import TestCase, override_settings
 from django.contrib.auth import get_user_model
+
 from venues.models import (
     Venue,
     Inspection,
@@ -109,3 +112,90 @@ class ReviewCommentModelTest(TestCase):
         self.assertEqual(
             str(self.comment), f"Comment by test@nyu.edu on review {self.review.id}"
         )
+
+
+@override_settings(GOOGLE_PLACES_API_KEY="test-api-key")
+class GooglePlacesPhotoTest(TestCase):
+    def setUp(self):
+        self.venue = Venue.objects.create(
+            name="Test Restaurant", google_place_id="ChIJtestplace123"
+        )
+
+    def _make_detail_response(self, photo_name="places/ChIJtest/photos/AUacXtest"):
+        resp = MagicMock()
+        resp.status_code = 200
+        resp.json.return_value = {"photos": [{"name": photo_name}]}
+        resp.raise_for_status = MagicMock()
+        return resp
+
+    def _make_media_response(self, location="https://lh3.googleusercontent.com/places/photo"):
+        resp = MagicMock()
+        resp.status_code = 302
+        resp.headers = {"Location": location}
+        return resp
+
+    @patch("venues.google_places.requests.get")
+    def test_fetches_and_caches_photo_on_first_call(self, mock_get):
+        cdn_url = "https://lh3.googleusercontent.com/places/photo"
+        mock_get.side_effect = [
+            self._make_detail_response(),
+            self._make_media_response(cdn_url),
+        ]
+
+        from venues.google_places import fetch_and_cache_primary_photo
+        result = fetch_and_cache_primary_photo(self.venue)
+
+        self.assertEqual(result, cdn_url)
+        self.assertEqual(mock_get.call_count, 2)
+        photo = VenuePhoto.objects.get(venue=self.venue, source="google_places")
+        self.assertEqual(photo.image_url, cdn_url)
+        self.assertTrue(photo.is_primary)
+
+    @patch("venues.google_places.requests.get")
+    def test_cached_photo_prevents_api_call(self, mock_get):
+        cdn_url = "https://lh3.googleusercontent.com/places/cached"
+        VenuePhoto.objects.create(
+            venue=self.venue,
+            image_url=cdn_url,
+            source="google_places",
+            is_primary=True,
+        )
+
+        from venues.google_places import fetch_and_cache_primary_photo
+        result = fetch_and_cache_primary_photo(self.venue)
+
+        self.assertEqual(result, cdn_url)
+        mock_get.assert_not_called()
+
+    @patch("venues.google_places.requests.get")
+    def test_api_failure_does_not_create_photo_row(self, mock_get):
+        mock_get.side_effect = Exception("network error")
+
+        from venues.google_places import fetch_and_cache_primary_photo
+        result = fetch_and_cache_primary_photo(self.venue)
+
+        self.assertIsNone(result)
+        self.assertFalse(VenuePhoto.objects.filter(venue=self.venue).exists())
+
+    @patch("venues.google_places.requests.get")
+    def test_non_redirect_response_does_not_store_api_key_url(self, mock_get):
+        # If Google returns 200 directly (no redirect), we must not store the URL
+        # because it would contain the API key.
+        detail_resp = self._make_detail_response()
+        media_resp = MagicMock()
+        media_resp.status_code = 200  # unexpected — no redirect
+        mock_get.side_effect = [detail_resp, media_resp]
+
+        from venues.google_places import fetch_and_cache_primary_photo
+        result = fetch_and_cache_primary_photo(self.venue)
+
+        self.assertIsNone(result)
+        self.assertFalse(VenuePhoto.objects.filter(venue=self.venue).exists())
+
+    def test_no_place_id_returns_none(self):
+        venue = Venue.objects.create(name="No Place ID Venue")
+
+        from venues.google_places import fetch_and_cache_primary_photo
+        result = fetch_and_cache_primary_photo(venue)
+
+        self.assertIsNone(result)


### PR DESCRIPTION
Adds a google_places utility that fetches the first photo for a venue using its stored google_place_id, follows the CDN redirect to get a stable image URL, and caches it in VenuePhoto so the API is only hit once per venue. _venue_to_swipe_json now triggers this on first load when no photos exist for a venue.