### PR TITLE
Feature/venue google places photos

### DIFF
--- a/backend/groups/tests.py
+++ b/backend/groups/tests.py
@@ -1,3 +1,5 @@
+from unittest.mock import patch
+
 from django.test import TestCase, Client
 from django.contrib.auth import get_user_model
 import json
@@ -872,6 +874,49 @@ class SwipeEventAPITests(TestCase):
         data = response.json()
         venue_names = [v["name"] for v in data["venues"]]
         self.assertNotIn("Ghost Venue", venue_names)
+
+    @patch("groups.views.bulk_prefetch_photos")
+    def test_venues_photos_appear_on_first_load(self, mock_bulk):
+        """Photos created by bulk_prefetch_photos must be visible on the first response,
+        not only after a second request (regression for stale prefetch cache bug)."""
+
+        venue = Venue.objects.create(
+            name="Photo Test Venue",
+            sanitation_grade="A",
+            is_active=True,
+            google_place_id="test_place_photo_load",
+        )
+
+        def _create_photo(venues_list, **kwargs):
+            for v in venues_list:
+                if v.id == venue.id:
+                    VenuePhoto.objects.get_or_create(
+                        venue=v,
+                        source="google_places",
+                        is_primary=True,
+                        defaults={
+                            "image_url": "https://lh3.googleusercontent.com/test"
+                        },
+                    )
+
+        mock_bulk.side_effect = _create_photo
+
+        event = SwipeEvent.objects.create(
+            group=self.group,
+            name="Photo Load Test",
+            created_by=self.leader,
+        )
+
+        self.client.login(email="leader@nyu.edu", password="pass123")
+        response = self.client.get(
+            f"/api/groups/{self.group.id}/events/{event.id}/venues/"
+        )
+        data = response.json()
+        match = next(
+            (v for v in data["venues"] if v["name"] == "Photo Test Venue"), None
+        )
+        self.assertIsNotNone(match)
+        self.assertIn("https://lh3.googleusercontent.com/test", match["images"])
 
 
 class GroupManagementAPITests(TestCase):

--- a/backend/groups/views.py
+++ b/backend/groups/views.py
@@ -1085,6 +1085,14 @@ def api_swipe_event_venues(request, group_id, event_id):
 
         venues_list = list(venues_qs)
         bulk_prefetch_photos(venues_list)
+        # Clear the stale photos cache from the original prefetch so
+        # prefetch_related_objects actually re-fetches (Django skips re-fetching
+        # if the key already exists in _prefetched_objects_cache).
+        for _v in venues_list:
+            try:
+                del _v._prefetched_objects_cache["photos"]
+            except (AttributeError, KeyError):
+                pass
         prefetch_related_objects(venues_list, "photos")
 
         venues_data = [_venue_to_swipe_json(v) for v in venues_list]

--- a/backend/groups/views.py
+++ b/backend/groups/views.py
@@ -1089,10 +1089,7 @@ def api_swipe_event_venues(request, group_id, event_id):
         # prefetch_related_objects actually re-fetches (Django skips re-fetching
         # if the key already exists in _prefetched_objects_cache).
         for _v in venues_list:
-            try:
-                del _v._prefetched_objects_cache["photos"]
-            except (AttributeError, KeyError):
-                pass
+            getattr(_v, "_prefetched_objects_cache", {}).pop("photos", None)
         prefetch_related_objects(venues_list, "photos")
 
         venues_data = [_venue_to_swipe_json(v) for v in venues_list]

--- a/backend/groups/views.py
+++ b/backend/groups/views.py
@@ -13,6 +13,7 @@ from django.utils import timezone
 from .models import Group, GroupMembership, SwipeEvent, Swipe, GroupInvitation
 from accounts.models import UserPreference
 from venues.models import Venue, VenuePhoto
+from venues.google_places import bulk_prefetch_photos
 from chat.models import Chat, ChatMember as ChatRoomMember, Message
 
 logger = logging.getLogger(__name__)
@@ -1081,8 +1082,6 @@ def api_swipe_event_venues(request, group_id, event_id):
         # Fetch missing Google Places photos in parallel (bulk_prefetch_photos) before
         # serializing, then refresh the prefetch cache so _venue_to_swipe_json only reads
         # already-loaded data and never performs API calls or DB writes itself.
-        from venues.google_places import bulk_prefetch_photos
-
         venues_list = list(venues_qs)
         bulk_prefetch_photos(venues_list)
         # Clear the stale photos cache from the original prefetch so

--- a/backend/venues/migrations/0005_alter_venuephoto_image_url.py
+++ b/backend/venues/migrations/0005_alter_venuephoto_image_url.py
@@ -1,0 +1,16 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("venues", "0004_venuephoto_unique_primary_photo_per_source"),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name="venuephoto",
+            name="image_url",
+            field=models.URLField(max_length=2048),
+        ),
+    ]

--- a/backend/venues/models.py
+++ b/backend/venues/models.py
@@ -175,7 +175,7 @@ class VenuePhoto(models.Model):
     """Photo references for venue profiles (Google Places URL or S3 URL)."""
 
     venue = models.ForeignKey(Venue, on_delete=models.CASCADE, related_name="photos")
-    image_url = models.URLField()
+    image_url = models.URLField(max_length=2048)
     source = models.CharField(max_length=50, blank=True)
     is_primary = models.BooleanField(default=False)
     caption = models.CharField(max_length=255, blank=True)

--- a/backend/venues/tests.py
+++ b/backend/venues/tests.py
@@ -63,6 +63,15 @@ class VenuePhotoModelTest(TestCase):
         self.photo.save()
         self.assertEqual(str(self.photo), "Test Restaurant — photo")
 
+    def test_image_url_supports_long_urls(self):
+        """image_url must accept URLs longer than 200 chars (e.g. Google CDN URLs)."""
+        long_url = "https://lh3.googleusercontent.com/places/photo/" + "a" * 300
+        photo = VenuePhoto.objects.create(
+            venue=self.venue, image_url=long_url, is_primary=False
+        )
+        photo.refresh_from_db()
+        self.assertEqual(photo.image_url, long_url)
+
 
 class VenueTidbitModelTest(TestCase):
     def setUp(self):


### PR DESCRIPTION
After the initial implementation, we hit two bugs from the logs:

Photos not showing on first load — Django was skipping the prefetch refresh because the empty photos cache from the original queryset was still in place. Fixed by explicitly clearing the stale cache entry before re-fetching.

value too long for type character varying(200) — Google's CDN redirect URLs are longer than 200 characters, which is Django's default URLField limit. Fixed by bumping VenuePhoto.image_url to max_length=2048 and adding a migration (0005) to apply it to Postgres.