### PR TITLE
ci: disable Travis shallow clone so Coveralls branch tracking works

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,12 @@ dist: noble # Use Ubuntu 24.04 'Noble' with a stable Python 3.12 environment
 node_js:
   - '20'
 
+# Disable shallow clone so Coveralls can find parent commits and properly
+# chain branch builds — shallow clones made every upload a "First build",
+# which broke Coveralls' branch-level aggregation.
+git:
+  depth: false
+
 install:
   # Ensure the environment uses Node 20 immediately
   - nvm install 20


### PR DESCRIPTION
## Summary

Fixes the pre-existing issue where Coveralls' branch-level aggregation has been stale for `develop` (currently showing 76% despite recent builds uploading 96.1%).

## Root cause

Travis uses a shallow clone by default (`depth=50`). When `coveralls` uploads, its parent-commit lookup fails against the shallow history, so every build is marked as **"First build"** on Coveralls with no chain to previous builds on the same branch. That breaks branch aggregation — the `?branch=develop` endpoint stops tracking the latest push.

Evidence:
- Travis build #145 (push, `72f8f10`, my PR #165 merge) passed and uploaded `96.149%` coverage → Coveralls [build 78830151](https://coveralls.io/builds/78830151)
- Coveralls repo-level data shows it correctly
- But `https://coveralls.io/github/gcivil-nyu-org/team2-mon-spring26.json?branch=develop` still returns `76.02%` with `calculated_at=2026-04-12T17:34:52Z` (an earlier PR build), and the README badge displays 76%
- Inspecting the Coveralls build pages confirms every recent build is labeled `First build` with empty graph data

This is also the same issue that previous attempts (#158, #160, #161, #162, #163) tried to fix.

## Change

Adds a top-level `git: depth: false` to `.travis.yml`, which makes Travis do a full clone. `coveralls` can then resolve parent SHAs and chain builds per branch correctly.

## Test plan

- [ ] Merge this PR into `develop`
- [ ] Confirm Travis build succeeds
- [ ] Confirm the Coveralls upload on the merge commit is **not** marked "First build" and the develop branch badge refreshes to the real coverage (~96% with PR #165's tests)