### PR TITLE
update travis yml to hopefully fix coveralls issue

### DIFF
--- a/.coveralls.yml
+++ b/.coveralls.yml
@@ -1,1 +1,0 @@
-service_name: travis-pro

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,9 +39,8 @@ script:
   # 3. Frontend Build
   - (cd frontend && npm run build)
 
-after_success:
-  - git checkout $TRAVIS_BRANCH
-  - (cd backend && coveralls)
+after_script:
+  - coveralls --service=travis-pro
 
 before_deploy:
   # Package only the backend directory for backend EB deploy


### PR DESCRIPTION
This pull request updates the Coveralls and Travis CI configuration to better align coverage reporting with the current CI/CD setup. The main change is switching from the deprecated `service_name: travis-pro` configuration and updating how Coveralls is invoked after tests.

**CI/CD and Coverage Reporting Updates:**

* Removed the `service_name: travis-pro` line from `.coveralls.yml` as it is no longer needed.
* Changed the Coveralls invocation in `.travis.yml`:
  - Moved the Coveralls command from the `after_success` section to `after_script`.
  - Updated the command to use `coveralls --service=travis-pro` for improved compatibility.