### PR TITLE
cd to backend before calling coveralls

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ script:
   - (cd frontend && npm run build)
 
 after_script:
-  - coveralls --service=travis-pro
+  - (cd backend && coveralls --service=travis-pro)
 
 before_deploy:
   # Package only the backend directory for backend EB deploy


### PR DESCRIPTION
This pull request makes a minor adjustment to the test coverage reporting step in the Travis CI configuration. The `coveralls` command is now run from within the `backend` directory to ensure coverage data is collected correctly for the backend code.