### PR TITLE
update coveralls badge from main branch in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Main: [![Coverage Status](https://coveralls.io/repos/github/gcivil-nyu-org/team2-mon-spring26/badge.svg?branch=develop)](https://coveralls.io/github/gcivil-nyu-org/team2-mon-spring26?branch=develop)
+Main: [![Coverage Status](https://coveralls.io/repos/github/gcivil-nyu-org/team2-mon-spring26/badge.svg?branch=main)](https://coveralls.io/github/gcivil-nyu-org/team2-mon-spring26?branch=main)
 [![Build Status](https://app.travis-ci.com/gcivil-nyu-org/team2-mon-spring26.svg?token=JELzXxdXXHqneS9SacAF&branch=main)](https://app.travis-ci.com/gcivil-nyu-org/team2-mon-spring26)
 
 Develop: [![Coverage Status](https://coveralls.io/repos/github/gcivil-nyu-org/team2-mon-spring26/badge.svg?branch=develop)](https://coveralls.io/github/gcivil-nyu-org/team2-mon-spring26?branch=develop)


### PR DESCRIPTION
This pull request makes a small update to the `README.md` file, correcting the coverage badge for the `main` branch so that it accurately reflects the coverage status for that branch instead of `develop`.