### PR TITLE
Fix Coveralls badge

### DIFF
--- a/.coveralls.yml
+++ b/.coveralls.yml
@@ -1,1 +1,0 @@
-service_name: travis-pro

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ script:
   - (cd frontend && npm run build)
 
 after_script:
-  - coveralls --service=travis-pro
+  - (cd backend && coveralls --service=travis-pro)
 
 before_deploy:
   # Package only the backend directory for backend EB deploy

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,9 +39,8 @@ script:
   # 3. Frontend Build
   - (cd frontend && npm run build)
 
-after_success:
-  - git checkout $TRAVIS_BRANCH
-  - (cd backend && coveralls)
+after_script:
+  - coveralls --service=travis-pro
 
 before_deploy:
   # Package only the backend directory for backend EB deploy

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Main: [![Coverage Status](https://coveralls.io/repos/github/gcivil-nyu-org/team2-mon-spring26/badge.svg?branch=develop)](https://coveralls.io/github/gcivil-nyu-org/team2-mon-spring26?branch=develop)
+Main: [![Coverage Status](https://coveralls.io/repos/github/gcivil-nyu-org/team2-mon-spring26/badge.svg?branch=main)](https://coveralls.io/github/gcivil-nyu-org/team2-mon-spring26?branch=main)
 [![Build Status](https://app.travis-ci.com/gcivil-nyu-org/team2-mon-spring26.svg?token=JELzXxdXXHqneS9SacAF&branch=main)](https://app.travis-ci.com/gcivil-nyu-org/team2-mon-spring26)
 
 Develop: [![Coverage Status](https://coveralls.io/repos/github/gcivil-nyu-org/team2-mon-spring26/badge.svg?branch=develop)](https://coveralls.io/github/gcivil-nyu-org/team2-mon-spring26?branch=develop)


### PR DESCRIPTION
This pull request updates the project's test coverage reporting and build configuration to better align with the current branch structure and CI setup. The most important changes are:

**Coverage reporting and CI configuration:**

* Changed the Coveralls badge in `README.md` for the main branch to reference the correct branch (`main` instead of `develop`).
* Updated the Coveralls invocation in `.travis.yml` to use the `after_script` phase and explicitly specify the service as `travis-pro`.
* Removed the `service_name: travis-pro` setting from `.coveralls.yml`, since this is now specified directly in the Coveralls command.