### PR TITLE
Fix/coveralls main badge

### DIFF
--- a/.coveralls.yml
+++ b/.coveralls.yml
@@ -1,1 +1,0 @@
-service_name: travis-pro

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ script:
   - (cd frontend && npm run build)
 
 after_script:
-  - coveralls --service=travis-pro
+  - (cd backend && coveralls --service=travis-pro)
 
 before_deploy:
   # Package only the backend directory for backend EB deploy

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,9 +39,8 @@ script:
   # 3. Frontend Build
   - (cd frontend && npm run build)
 
-after_success:
-  - git checkout $TRAVIS_BRANCH
-  - (cd backend && coveralls)
+after_script:
+  - coveralls --service=travis-pro
 
 before_deploy:
   # Package only the backend directory for backend EB deploy

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Main: [![Coverage Status](https://coveralls.io/repos/github/gcivil-nyu-org/team2-mon-spring26/badge.svg?branch=develop)](https://coveralls.io/github/gcivil-nyu-org/team2-mon-spring26?branch=develop)
+Main: [![Coverage Status](https://coveralls.io/repos/github/gcivil-nyu-org/team2-mon-spring26/badge.svg?branch=main)](https://coveralls.io/github/gcivil-nyu-org/team2-mon-spring26?branch=main)
 [![Build Status](https://app.travis-ci.com/gcivil-nyu-org/team2-mon-spring26.svg?token=JELzXxdXXHqneS9SacAF&branch=main)](https://app.travis-ci.com/gcivil-nyu-org/team2-mon-spring26)
 
 Develop: [![Coverage Status](https://coveralls.io/repos/github/gcivil-nyu-org/team2-mon-spring26/badge.svg?branch=develop)](https://coveralls.io/github/gcivil-nyu-org/team2-mon-spring26?branch=develop)


### PR DESCRIPTION
This pull request updates the project's test coverage reporting setup and improves the documentation to display coverage and build status for both the `main` and `develop` branches. The changes primarily focus on aligning the Coveralls configuration with Travis CI and making status badges clearer in the `README.md`.

**CI/CD and Coverage Reporting Updates:**

* Updated the Coveralls invocation in the Travis CI configuration to explicitly specify the `travis-pro` service using the `--service=travis-pro` flag, and moved it from the `after_success` to the `after_script` section for better compatibility. (`.travis.yml`)
* Removed the now-unnecessary `service_name: travis-pro` setting from the `.coveralls.yml` configuration file to prevent conflicts and redundancy. (`.coveralls.yml`)

**Documentation Improvements:**

* Revised the `README.md` to show separate coverage and build status badges for both the `main` and `develop` branches, making it easier to track the status of each branch. (`README.md`)