### PR TITLE
Audit fixes

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -4,11 +4,12 @@ max-line-length = 88
 # Tell it to ignore the long line errors (E501) entirely for now
 ignore = E501, E203, W503
 # Exclude folders that shouldn't be linted
-exclude = 
+exclude =
     .git,
     __pycache__,
     */migrations/*,
     venv,
+    .venv,
     env,
     .tox,
     build,

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ script:
   - (cd frontend && npm run lint)
 
   # 2. Backend Tests & Coverage
-  - (cd backend && coverage run --rcfile=../.coveragerc --source=. manage.py test)
+  - (cd backend && coverage run --rcfile=../.coveragerc --source=. manage.py test --settings=config.test_settings)
 
   # 3. Frontend Build
   - (cd frontend && npm run build)

--- a/README.md
+++ b/README.md
@@ -319,7 +319,7 @@ Keep tests close to feature work and treat them as part of every PR.
 - Prefer queries users rely on (`getByRole`, `getByText`) over brittle selectors.
 - Cover loading, empty, error, and success UI states where applicable.
 - Keep tests isolated and avoid shared mutable state between test cases.
-- _Note:_ Frontend test setup (Vitest + React Testing Library) is in place, but tests may not pass under Vite 8 beta without version/config alignment; see `docs/TEST_RESULTS.md` for current status and recommendations.
+- See `docs/TEST_RESULTS.md` for current test status and how to run the test suites.
 
 #### Team Expectations
 

--- a/README.md
+++ b/README.md
@@ -329,17 +329,25 @@ Keep tests close to feature work and treat them as part of every PR.
 
 ### ✨ Running backend tests locally
 
-From the `backend/` directory (with `config.settings`):
+From the `backend/` directory:
 
 ```sh
-python manage.py test                              # run everything
-python manage.py test tests.test_auth_integration -v 2   # auth suite only
+# Recommended: use test_settings for faster runs (MD5 hasher, in-memory email)
+python manage.py test --settings=config.test_settings
 
-# Run a single test method (use `tests.` as the module prefix, not `backend.tests.`):
-python manage.py test tests.test_auth_integration.AuthIntegrationTests.test_login_success -v 2
+# Keep the test database between runs (avoids recreating it each time)
+python manage.py test --settings=config.test_settings --keepdb
+
+# Run a specific app or test class
+python manage.py test accounts --settings=config.test_settings --keepdb
+python manage.py test accounts.CSRFProtectionTests --settings=config.test_settings --keepdb
+
+# Run a single test method
+python manage.py test accounts.tests.AuthViewsTests.test_login_success --settings=config.test_settings -v 2
 ```
 
-Use the module path **`tests.test_auth_integration`** (not `backend.tests...`). Django treats the first segment as an app name; we have no app called `backend`, so `backend.tests.test_auth_integration` raises `ModuleNotFoundError`.
+**Why `--settings=config.test_settings`?**
+`config/test_settings.py` overrides `PASSWORD_HASHERS` to use `MD5PasswordHasher` instead of PBKDF2-SHA256 (260k rounds). With ~57 password-hashing calls across the full suite this saves significant time. It also silences console email output. Production settings are unaffected.
 
 ### 8.2 Feature Test Suites (Progress & Coverage)
 

--- a/README.md
+++ b/README.md
@@ -340,10 +340,10 @@ python manage.py test --settings=config.test_settings --keepdb
 
 # Run a specific app or test class
 python manage.py test accounts --settings=config.test_settings --keepdb
-python manage.py test accounts.CSRFProtectionTests --settings=config.test_settings --keepdb
+python manage.py test accounts.tests.CSRFProtectionTests --settings=config.test_settings --keepdb
 
 # Run a single test method
-python manage.py test accounts.tests.AuthViewsTests.test_login_success --settings=config.test_settings -v 2
+python manage.py test accounts.tests.AuthIntegrationTests.test_login_success --settings=config.test_settings -v 2
 ```
 
 **Why `--settings=config.test_settings`?**

--- a/backend/accounts/tests.py
+++ b/backend/accounts/tests.py
@@ -1323,7 +1323,9 @@ class CSRFProtectionTests(TestCase):
     def _get_csrf_token(self):
         """Hit api_me (ensure_csrf_cookie) to receive a CSRF cookie, then return it."""
         resp = self.csrf_client.get(reverse("api_me"))
-        return resp.cookies.get("csrftoken", "").value
+        cookie = resp.cookies.get("csrftoken")
+        self.assertIsNotNone(cookie, "api_me did not set a csrftoken cookie")
+        return cookie.value
 
     def _login_session(self):
         """Log the test user in via the normal login endpoint (requires CSRF)."""

--- a/backend/accounts/tests.py
+++ b/backend/accounts/tests.py
@@ -1298,6 +1298,7 @@ class VenueManagerProfileTests(TestCase):
             user=self.user, business_name="Joe's Diner"
         )
         self.assertIn("Joe's Diner", str(profile))
+        self.assertIn(self.user.email, str(profile))
 
 
 # ---------------------------------------------------------------------------

--- a/backend/accounts/tests.py
+++ b/backend/accounts/tests.py
@@ -1371,7 +1371,11 @@ class CSRFProtectionTests(TestCase):
         resp = self.csrf_client.post(
             reverse("api_register"),
             data=json.dumps(
-                {"email": "new@nyu.edu", "password": "StrongPass!1", "first_name": "New"}
+                {
+                    "email": "new@nyu.edu",
+                    "password": "StrongPass!1",
+                    "first_name": "New",
+                }
             ),
             content_type="application/json",
         )
@@ -1382,7 +1386,11 @@ class CSRFProtectionTests(TestCase):
         resp = self.csrf_client.post(
             reverse("api_register"),
             data=json.dumps(
-                {"email": "new@nyu.edu", "password": "StrongPass!1", "first_name": "New"}
+                {
+                    "email": "new@nyu.edu",
+                    "password": "StrongPass!1",
+                    "first_name": "New",
+                }
             ),
             content_type="application/json",
             HTTP_X_CSRFTOKEN=token,

--- a/backend/accounts/tests.py
+++ b/backend/accounts/tests.py
@@ -1298,4 +1298,157 @@ class VenueManagerProfileTests(TestCase):
             user=self.user, business_name="Joe's Diner"
         )
         self.assertIn("Joe's Diner", str(profile))
-        self.assertIn("manager@nyu.edu", str(profile))
+
+
+# ---------------------------------------------------------------------------
+# CSRF protection tests
+# ---------------------------------------------------------------------------
+
+
+class CSRFProtectionTests(TestCase):
+    """
+    Verify that all state-changing auth endpoints require a valid CSRF token
+    when using session-cookie authentication.
+
+    Uses Client(enforce_csrf_checks=True) so Django's CSRF middleware is fully
+    active (the default test client bypasses it).
+    """
+
+    def setUp(self):
+        self.csrf_client = Client(enforce_csrf_checks=True)
+        self.user = User.objects.create_user(
+            email="csrf@nyu.edu", password="StrongPass!1"
+        )
+
+    def _get_csrf_token(self):
+        """Hit api_me (ensure_csrf_cookie) to receive a CSRF cookie, then return it."""
+        resp = self.csrf_client.get(reverse("api_me"))
+        return resp.cookies.get("csrftoken", "").value
+
+    def _login_session(self):
+        """Log the test user in via the normal login endpoint (requires CSRF)."""
+        token = self._get_csrf_token()
+        self.csrf_client.post(
+            reverse("api_login"),
+            data=json.dumps({"email": "csrf@nyu.edu", "password": "StrongPass!1"}),
+            content_type="application/json",
+            HTTP_X_CSRFTOKEN=token,
+        )
+
+    # --- api_me sets CSRF cookie (GET, no token needed) ---
+
+    def test_api_me_sets_csrf_cookie(self):
+        resp = self.csrf_client.get(reverse("api_me"))
+        self.assertIn("csrftoken", resp.cookies)
+
+    # --- Login: POST without token → 403 ---
+
+    def test_login_without_csrf_token_is_rejected(self):
+        self._get_csrf_token()  # ensure cookie is set
+        resp = self.csrf_client.post(
+            reverse("api_login"),
+            data=json.dumps({"email": "csrf@nyu.edu", "password": "StrongPass!1"}),
+            content_type="application/json",
+            # deliberately omit HTTP_X_CSRFTOKEN
+        )
+        self.assertEqual(resp.status_code, 403)
+
+    def test_login_with_csrf_token_succeeds(self):
+        token = self._get_csrf_token()
+        resp = self.csrf_client.post(
+            reverse("api_login"),
+            data=json.dumps({"email": "csrf@nyu.edu", "password": "StrongPass!1"}),
+            content_type="application/json",
+            HTTP_X_CSRFTOKEN=token,
+        )
+        self.assertEqual(resp.status_code, 200)
+        self.assertTrue(resp.json()["success"])
+
+    # --- Register: POST without token → 403 ---
+
+    def test_register_without_csrf_token_is_rejected(self):
+        self._get_csrf_token()
+        resp = self.csrf_client.post(
+            reverse("api_register"),
+            data=json.dumps(
+                {"email": "new@nyu.edu", "password": "StrongPass!1", "first_name": "New"}
+            ),
+            content_type="application/json",
+        )
+        self.assertEqual(resp.status_code, 403)
+
+    def test_register_with_csrf_token_succeeds(self):
+        token = self._get_csrf_token()
+        resp = self.csrf_client.post(
+            reverse("api_register"),
+            data=json.dumps(
+                {"email": "new@nyu.edu", "password": "StrongPass!1", "first_name": "New"}
+            ),
+            content_type="application/json",
+            HTTP_X_CSRFTOKEN=token,
+        )
+        self.assertEqual(resp.status_code, 200)
+        self.assertTrue(resp.json()["success"])
+
+    # --- Logout: POST without token → 403 ---
+
+    def test_logout_without_csrf_token_is_rejected(self):
+        self._login_session()
+        # do NOT pass X-CSRFToken
+        resp = self.csrf_client.post(reverse("api_logout"))
+        self.assertEqual(resp.status_code, 403)
+
+    def test_logout_with_csrf_token_succeeds(self):
+        self._login_session()
+        token = self._get_csrf_token()
+        resp = self.csrf_client.post(
+            reverse("api_logout"),
+            HTTP_X_CSRFTOKEN=token,
+        )
+        self.assertEqual(resp.status_code, 200)
+        self.assertTrue(resp.json()["success"])
+
+    # --- Preferences: PATCH without token → 403 ---
+
+    def test_preferences_update_without_csrf_token_is_rejected(self):
+        self._login_session()
+        resp = self.csrf_client.patch(
+            reverse("api_preferences_update"),
+            data=json.dumps({"dietary": ["Vegan"]}),
+            content_type="application/json",
+        )
+        self.assertEqual(resp.status_code, 403)
+
+    def test_preferences_update_with_csrf_token_succeeds(self):
+        self._login_session()
+        token = self._get_csrf_token()
+        resp = self.csrf_client.patch(
+            reverse("api_preferences_update"),
+            data=json.dumps({"dietary": ["Vegan"]}),
+            content_type="application/json",
+            HTTP_X_CSRFTOKEN=token,
+        )
+        self.assertEqual(resp.status_code, 200)
+
+    # --- Password reset request: POST without token → 403 ---
+
+    def test_password_reset_request_without_csrf_token_is_rejected(self):
+        self._get_csrf_token()
+        resp = self.csrf_client.post(
+            reverse("api_request_password_reset"),
+            data=json.dumps({"email": "csrf@nyu.edu"}),
+            content_type="application/json",
+        )
+        self.assertEqual(resp.status_code, 403)
+
+    @patch("accounts.views.send_password_reset_email")
+    def test_password_reset_request_with_csrf_token_succeeds(self, mock_send):
+        token = self._get_csrf_token()
+        resp = self.csrf_client.post(
+            reverse("api_request_password_reset"),
+            data=json.dumps({"email": "csrf@nyu.edu"}),
+            content_type="application/json",
+            HTTP_X_CSRFTOKEN=token,
+        )
+        self.assertEqual(resp.status_code, 200)
+        self.assertTrue(resp.json()["success"])

--- a/backend/accounts/tests.py
+++ b/backend/accounts/tests.py
@@ -1328,11 +1328,16 @@ class CSRFProtectionTests(TestCase):
     def _login_session(self):
         """Log the test user in via the normal login endpoint (requires CSRF)."""
         token = self._get_csrf_token()
-        self.csrf_client.post(
+        resp = self.csrf_client.post(
             reverse("api_login"),
             data=json.dumps({"email": "csrf@nyu.edu", "password": "StrongPass!1"}),
             content_type="application/json",
             HTTP_X_CSRFTOKEN=token,
+        )
+        self.assertEqual(
+            resp.status_code,
+            200,
+            f"CSRF login precondition failed (status {resp.status_code}): {resp.content!r}",
         )
 
     # --- api_me sets CSRF cookie (GET, no token needed) ---

--- a/backend/accounts/views.py
+++ b/backend/accounts/views.py
@@ -12,7 +12,7 @@ from django.core.exceptions import ValidationError
 from django.conf import settings
 from django.http import JsonResponse
 from django.core.cache import cache
-from django.views.decorators.csrf import ensure_csrf_cookie, csrf_exempt
+from django.views.decorators.csrf import ensure_csrf_cookie
 from django.utils.http import urlsafe_base64_decode, urlsafe_base64_encode
 from django.utils.encoding import force_bytes
 
@@ -149,7 +149,6 @@ def _user_to_json(user):
     return payload
 
 
-@csrf_exempt
 def api_venue_register(request):
     """
     POST /api/auth/venue-register/
@@ -213,7 +212,6 @@ def api_venue_register(request):
         )
 
 
-@csrf_exempt
 def api_admin_register(request):
     """
     POST /api/auth/admin-register/
@@ -292,7 +290,6 @@ signup = SignUpView.as_view()
 # --- JSON API Views for React Frontend ---
 
 
-@csrf_exempt
 def api_register(request):
     if request.method == "POST":
         try:
@@ -329,7 +326,6 @@ def api_register(request):
     return JsonResponse({"error": "Method not allowed"}, status=405)
 
 
-@csrf_exempt
 def api_login(request):
     if request.method == "POST":
         # basic brute force mitigation: limit by IP and email
@@ -372,7 +368,6 @@ def api_login(request):
     return JsonResponse({"error": "Method not allowed"}, status=405)
 
 
-@csrf_exempt
 def api_admin_login(request):
     if request.method != "POST":
         return JsonResponse({"error": "Method not allowed"}, status=405)
@@ -406,7 +401,6 @@ def api_admin_login(request):
         )
 
 
-@csrf_exempt
 def api_logout(request):
     if request.method == "POST":
         logout(request)
@@ -426,7 +420,6 @@ def api_me(request):
     return JsonResponse({"authenticated": False}, status=401)
 
 
-@csrf_exempt
 def api_preferences_update(request):
     if request.method not in ("PATCH", "PUT"):
         return JsonResponse({"error": "Method not allowed"}, status=405)
@@ -444,7 +437,6 @@ def api_preferences_update(request):
         )
 
 
-@csrf_exempt
 def api_request_password_reset(request):
     if request.method == "POST":
         try:
@@ -512,7 +504,6 @@ def api_request_password_reset(request):
     return JsonResponse({"error": "Method not allowed"}, status=405)
 
 
-@csrf_exempt
 def api_request_admin_password_reset(request):
     if request.method != "POST":
         return JsonResponse({"error": "Method not allowed"}, status=405)
@@ -575,7 +566,6 @@ def api_request_admin_password_reset(request):
         )
 
 
-@csrf_exempt
 def api_validate_password_reset_token(request):
     if request.method != "POST":
         return JsonResponse({"error": "Method not allowed"}, status=405)
@@ -613,7 +603,6 @@ def api_validate_password_reset_token(request):
     return JsonResponse({"success": True, "valid": True})
 
 
-@csrf_exempt
 def api_confirm_password_reset(request):
     if request.method != "POST":
         return JsonResponse({"error": "Method not allowed"}, status=405)

--- a/backend/chat/views.py
+++ b/backend/chat/views.py
@@ -1,7 +1,6 @@
 import json
 import logging
 from django.http import JsonResponse
-from django.views.decorators.csrf import csrf_exempt
 from django.contrib.auth import get_user_model
 from django.db import transaction
 from django.utils import timezone
@@ -92,7 +91,6 @@ def _chat_to_json(chat, request_user=None):
     }
 
 
-@csrf_exempt
 def api_chat_list_create(request):
     """
     GET /api/chat/ - List all chats the user is a member of (Groups and DMs)
@@ -197,7 +195,6 @@ def api_chat_list_create(request):
     return JsonResponse({"error": "Method not allowed"}, status=405)
 
 
-@csrf_exempt
 def api_chat_messages(request, chat_id):
     """
     GET /api/chat/<id>/messages/
@@ -316,7 +313,6 @@ def api_chat_messages(request, chat_id):
         return JsonResponse({"error": "An expected error occurred"}, status=500)
 
 
-@csrf_exempt
 def api_chat_message_detail(request, chat_id, message_id):
     """
     DELETE /api/chat/<chat_id>/messages/<message_id>/
@@ -374,7 +370,6 @@ def api_chat_message_detail(request, chat_id, message_id):
         return JsonResponse({"error": "An expected error occurred"}, status=500)
 
 
-@csrf_exempt
 def api_chat_member_mute(request, chat_id, user_id):
     """
     POST /api/chat/<chat_id>/members/<user_id>/mute/

--- a/backend/config/test_settings.py
+++ b/backend/config/test_settings.py
@@ -1,0 +1,24 @@
+"""
+Test-only settings. Inherits everything from the main settings module and
+overrides only what makes tests faster or more deterministic.
+
+Usage:
+    python manage.py test --settings=config.test_settings
+
+Or set the environment variable once:
+    export DJANGO_SETTINGS_MODULE=config.test_settings
+"""
+
+from config.settings import *  # noqa: F401, F403
+
+# Use the fast MD5 hasher during tests.
+# PBKDF2-SHA256 (the production default) runs 260 000 iterations per hash —
+# slow by design for security. With ~57 create_user/set_password calls across
+# the test suite this adds tens of seconds. MD5 is cryptographically broken
+# but fine for throwaway test fixtures that never touch real user data.
+PASSWORD_HASHERS = [
+    "django.contrib.auth.hashers.MD5PasswordHasher",
+]
+
+# Suppress console email output during tests so stderr stays clean.
+EMAIL_BACKEND = "django.core.mail.backends.locmem.EmailBackend"

--- a/backend/groups/views.py
+++ b/backend/groups/views.py
@@ -2,7 +2,6 @@ import json
 import logging
 import math
 from django.http import JsonResponse
-from django.views.decorators.csrf import csrf_exempt
 from django.contrib.auth import get_user_model
 from django.db import transaction, models
 from django.db.models import Count, prefetch_related_objects
@@ -20,7 +19,6 @@ logger = logging.getLogger(__name__)
 User = get_user_model()
 
 
-@csrf_exempt
 def api_list_users(request):
     """
     GET /api/groups/users/
@@ -119,7 +117,6 @@ def _group_to_json(group):
     }
 
 
-@csrf_exempt
 def api_groups_list_create(request):
     """
     GET /api/groups/ - List all groups the user is a member of
@@ -190,7 +187,6 @@ def api_groups_list_create(request):
     return JsonResponse({"error": "Method not allowed"}, status=405)
 
 
-@csrf_exempt
 def api_edit_group(request, group_id):
     """
     PATCH|PUT /api/groups/<id>/
@@ -245,7 +241,6 @@ def api_edit_group(request, group_id):
         return JsonResponse({"error": "An expected error occurred"}, status=500)
 
 
-@csrf_exempt
 def api_delete_group(request, group_id):
     """
     DELETE /api/groups/<id>/
@@ -277,7 +272,6 @@ def api_delete_group(request, group_id):
         return JsonResponse({"error": "An expected error occurred"}, status=500)
 
 
-@csrf_exempt
 def api_invite_to_group(request, group_id):
     """
     POST /api/groups/<id>/invite/
@@ -344,7 +338,6 @@ def api_invite_to_group(request, group_id):
         return JsonResponse({"error": "An expected error occurred"}, status=500)
 
 
-@csrf_exempt
 def api_invitations_list(request):
     """
     GET /api/groups/invitations/
@@ -411,7 +404,6 @@ def api_invitations_list(request):
     )
 
 
-@csrf_exempt
 def api_mark_swipe_notification_read(request, notification_id):
     if request.method != "POST":
         return JsonResponse({"error": "Method not allowed"}, status=405)
@@ -434,7 +426,6 @@ def api_mark_swipe_notification_read(request, notification_id):
         return JsonResponse({"error": "An expected error occurred"}, status=500)
 
 
-@csrf_exempt
 def api_invitation_action(request, invitation_id, action):
     """
     POST /api/groups/invitations/<invitation_id>/<action>/
@@ -505,7 +496,6 @@ def api_invitation_action(request, invitation_id, action):
         return JsonResponse({"error": "An expected error occurred"}, status=500)
 
 
-@csrf_exempt
 def api_remove_from_group(request, group_id, user_id):
     """
     DELETE /api/groups/<id>/members/<user_id>/
@@ -569,7 +559,6 @@ def api_remove_from_group(request, group_id, user_id):
         return JsonResponse({"error": "An expected error occurred"}, status=500)
 
 
-@csrf_exempt
 def api_make_leader(request, group_id, user_id):
     """
     PATCH /api/groups/<id>/members/<user_id>/role/
@@ -628,7 +617,6 @@ def api_make_leader(request, group_id, user_id):
         return JsonResponse({"error": "An expected error occurred"}, status=500)
 
 
-@csrf_exempt
 def api_update_group_constraints(request, group_id):
     if request.method not in ("PATCH", "PUT"):
         return JsonResponse({"error": "Method not allowed"}, status=405)
@@ -727,7 +715,6 @@ def api_update_group_constraints(request, group_id):
         return JsonResponse({"error": "Internal server error"}, status=500)
 
 
-@csrf_exempt
 def api_leave_group(request, group_id):
     """
     POST /api/groups/<id>/leave/
@@ -897,7 +884,6 @@ def _venue_to_swipe_json(venue):
     }
 
 
-@csrf_exempt
 def api_swipe_events(request, group_id):
     """
     GET  /api/groups/<id>/events/ - List swipe events for a group
@@ -974,7 +960,6 @@ def api_swipe_events(request, group_id):
         return JsonResponse({"error": "An unexpected error occurred"}, status=500)
 
 
-@csrf_exempt
 def api_swipe_event_venues(request, group_id, event_id):
     """
     GET /api/groups/<id>/events/<event_id>/venues/
@@ -1103,7 +1088,6 @@ def api_swipe_event_venues(request, group_id, event_id):
         return JsonResponse({"error": "An unexpected error occurred"}, status=500)
 
 
-@csrf_exempt
 def api_submit_swipe(request, group_id, event_id):
     """
     POST /api/groups/<id>/events/<event_id>/swipes/
@@ -1172,7 +1156,6 @@ def api_submit_swipe(request, group_id, event_id):
         return JsonResponse({"error": "An unexpected error occurred"}, status=500)
 
 
-@csrf_exempt
 def api_swipe_event_results(request, group_id, event_id):
     """
     GET /api/groups/<id>/events/<event_id>/results/
@@ -1276,7 +1259,6 @@ def api_swipe_event_results(request, group_id, event_id):
         return JsonResponse({"error": "An unexpected error occurred"}, status=500)
 
 
-@csrf_exempt
 def api_public_groups_list(request):
     if request.method != "GET":
         return JsonResponse({"error": "Method not allowed"}, status=405)
@@ -1297,7 +1279,6 @@ def api_public_groups_list(request):
         return JsonResponse({"error": "An expected error occurred"}, status=500)
 
 
-@csrf_exempt
 def api_join_group_by_code(request, join_code):
     if request.method != "POST":
         return JsonResponse({"error": "Method not allowed"}, status=405)
@@ -1348,7 +1329,6 @@ def api_join_group_by_code(request, join_code):
         return JsonResponse({"error": "An expected error occurred"}, status=500)
 
 
-@csrf_exempt
 def api_regenerate_join_code(request, group_id):
     if request.method != "POST":
         return JsonResponse({"error": "Method not allowed"}, status=405)

--- a/backend/venues/views.py
+++ b/backend/venues/views.py
@@ -3,7 +3,6 @@ import logging
 import math
 
 from django.http import JsonResponse
-from django.views.decorators.csrf import csrf_exempt
 from django.db import transaction
 from django.utils import timezone
 
@@ -98,7 +97,6 @@ def _discount_to_json(discount):
     }
 
 
-@csrf_exempt
 def api_venue_search(request):
     """
     GET /api/venues/search/?q=&borough=
@@ -174,7 +172,6 @@ def api_venue_search(request):
     return JsonResponse({"results": results})
 
 
-@csrf_exempt
 def api_venue_claim(request, venue_id):
     """
     POST /api/venues/<id>/claim/
@@ -224,7 +221,6 @@ def api_venue_claim(request, venue_id):
     return JsonResponse({"success": True, "venue": _venue_to_json(venue)}, status=201)
 
 
-@csrf_exempt
 def api_my_venues(request):
     """
     GET /api/venues/my-venues/
@@ -247,7 +243,6 @@ def api_my_venues(request):
     return JsonResponse({"venues": [_venue_to_json(v) for v in venues]})
 
 
-@csrf_exempt
 def api_venue_detail(request, venue_id):
     """
     GET /api/venues/<id>/
@@ -272,7 +267,6 @@ def api_venue_detail(request, venue_id):
     return JsonResponse({"venue": _venue_to_json(venue)})
 
 
-@csrf_exempt
 def api_venue_discounts(request, venue_id):
     """
     GET  /api/venues/<id>/discounts/  — list discounts
@@ -320,7 +314,6 @@ def api_venue_discounts(request, venue_id):
     return JsonResponse({"error": "Method not allowed"}, status=405)
 
 
-@csrf_exempt
 def api_venue_discount_detail(request, venue_id, discount_id):
     """
     PATCH  /api/venues/<venue_id>/discounts/<discount_id>/  — update
@@ -403,7 +396,6 @@ def _require_admin(request):
     return None
 
 
-@csrf_exempt
 def api_admin_venue_claims(request):
     """
     GET /api/venues/admin/claims/?status=pending&page=1
@@ -484,7 +476,6 @@ def api_admin_venue_claims(request):
     )
 
 
-@csrf_exempt
 def api_admin_venue_claim_action(request, claim_id):
     """
     POST /api/venues/admin/claims/<claim_id>/
@@ -608,7 +599,6 @@ def _admin_venue_to_json(venue):
     }
 
 
-@csrf_exempt
 def api_admin_venue_options(request):
     """
     GET /api/venues/admin/options/
@@ -635,7 +625,6 @@ def api_admin_venue_options(request):
     )
 
 
-@csrf_exempt
 def api_admin_venues(request):
     """
     GET /api/venues/admin/venues/?q=&borough=&page=1
@@ -697,7 +686,6 @@ def api_admin_venues(request):
     )
 
 
-@csrf_exempt
 def api_admin_venue_detail(request, venue_id):
     """
     GET   /api/venues/admin/venues/<id>/  — full venue detail

--- a/docs/TEST_RESULTS.md
+++ b/docs/TEST_RESULTS.md
@@ -33,6 +33,30 @@ The chunk size warning from `npm run build` is expected for this bundle size. It
 | Login rate limiting    | 2     | ✅ Pass        |
 | **Total**              | **17**| **✅ All pass**|
 
+---
+
+## Backend: CSRF protection tests
+
+**Suite:** `backend/accounts/tests.py` — `CSRFProtectionTests`
+**Run from:** `backend/` directory
+**Command:** `python manage.py test accounts.CSRFProtectionTests -v 2`
+
+These tests use `Client(enforce_csrf_checks=True)` to verify that all
+state-changing endpoints enforce Django's CSRF middleware after removing
+all `@csrf_exempt` decorators in WS1.
+
+### Summary
+
+| Endpoint                         | Without token | With token | Status     |
+|----------------------------------|---------------|------------|------------|
+| `GET /api/auth/me/`              | Sets cookie   | —          | ✅ Pass    |
+| `POST /api/auth/login/`          | 403           | 200        | ✅ Pass    |
+| `POST /api/auth/register/`       | 403           | 200        | ✅ Pass    |
+| `POST /api/auth/logout/`         | 403           | 200        | ✅ Pass    |
+| `PATCH /api/auth/preferences/`   | 403           | 200        | ✅ Pass    |
+| `POST /api/auth/request-password-reset/` | 403   | 200        | ✅ Pass    |
+| **Total**                        | **6 reject**  | **5 accept**| **✅ All pass** |
+
 ### Coverage by feature
 
 - **Registration:** success (hash password, auto-login), duplicate email, invalid email, GET → 405.
@@ -49,6 +73,9 @@ Use the full test path (Django expects the first segment to be an app name; we u
 ```sh
 cd backend
 python manage.py test tests.test_auth_integration.AuthIntegrationTests.test_login_success -v 2
+
+# Run the full CSRF suite (lives in the accounts app):
+python manage.py test accounts.CSRFProtectionTests -v 2
 ```
 
 ---

--- a/docs/TEST_RESULTS.md
+++ b/docs/TEST_RESULTS.md
@@ -1,36 +1,37 @@
 # Test Results
 
-## ⚠️ Why frontend tests fail under Vite 8
+## Frontend toolchain status
 
-**The failures are not due to bugs in our application or test code.** Our login/register tests and business logic are written in a normal, correct way.
+All three frontend commands pass:
 
-**Possible causes (not 100% confirmed):**
+```sh
+cd frontend
+npm run lint      # ESLint — clean
+npm run test:run  # Vitest — 6 files, 20 tests, all pass
+npm run build     # Vite build — succeeds (~765 kB bundle, gzip ~224 kB)
+```
 
-- **Current test run environment:** When running tests with **Vite 8 beta + Vitest**, loading app code can trigger an SSR-like module transform, leading to `__vite_ssr_exportName__ is not defined` or component exports becoming `undefined` (“Element type is invalid... got: undefined”).
-- This may be **default behavior when using Vite 8 beta with Vitest** (there may be no official “fix”; we may need to turn off SSR transform for tests in config).
-- It could also be that **our project’s Vite/Vitest configuration** is not set up correctly (e.g. SSR applied during tests, or missing options like `transformMode`), and needs to be revisited against the official docs.
-
-**Conclusion:** The issue is with the **current test environment/configuration**, not with the application or tests. **Do not rely on “waiting for Vite 8 to fix it.”** A more reliable approach is to get frontend tests passing using one of the options below (e.g. temporarily switching to Vite 5 for tests), or later to look up Vitest/Vite docs for a “disable SSR transform for tests” option and apply it.
+The chunk size warning from `npm run build` is expected for this bundle size. It is a warning, not an error, and does not block the build.
 
 ---
 
 ## Backend: Authentication integration tests
 
-**Suite:** `backend/tests/test_auth_integration.py`  
-**Run from:** `backend/` directory  
+**Suite:** `backend/tests/test_auth_integration.py`
+**Run from:** `backend/` directory
 **Command:** `python manage.py test tests.test_auth_integration -v 2`
 
 ### Summary
 
-| Area              | Tests | Status |
-|-------------------|-------|--------|
-| Registration      | 4     | ✅ Pass |
-| Login             | 3     | ✅ Pass |
-| Logout            | 2     | ✅ Pass |
-| Current user / me | 2     | ✅ Pass |
-| Password reset request | 4 | ✅ Pass |
-| Login rate limiting | 2  | ✅ Pass |
-| **Total**         | **17**| **✅ All pass** |
+| Area                   | Tests | Status        |
+|------------------------|-------|---------------|
+| Registration           | 4     | ✅ Pass        |
+| Login                  | 3     | ✅ Pass        |
+| Logout                 | 2     | ✅ Pass        |
+| Current user / me      | 2     | ✅ Pass        |
+| Password reset request | 4     | ✅ Pass        |
+| Login rate limiting    | 2     | ✅ Pass        |
+| **Total**              | **17**| **✅ All pass**|
 
 ### Coverage by feature
 
@@ -56,38 +57,31 @@ python manage.py test tests.test_auth_integration.AuthIntegrationTests.test_logi
 
 **Setup:** Vitest + React Testing Library + jsdom (see `frontend/package.json` scripts `test`, `test:run`).
 
-**Run from:** `frontend/` directory  
+**Run from:** `frontend/` directory
 **Commands:**
 ```sh
 cd frontend
 npm run test        # watch mode
 npm run test:run    # single run
-npm run test:run -- src/test/smoke.test.ts   # run only smoke test
 ```
 
-### Implemented
+### Test files
 
-- **Smoke test** (`src/test/smoke.test.ts`): Confirms Vitest and jsdom run; always runnable.
-- **Login page** (`src/app/pages/login-page.test.tsx`): Renders form, invalid credentials error, forgot-password dialog, validation, reset success message.
-- **Register page** (`src/app/pages/register-page.test.tsx`): Account step fields, validation (name, email, password length, password match), preferences step, API error message.
-
-### Running frontend tests under Vite 8 (current behavior and options)
-
-Under **Vite 8 beta + Vitest**, loading app code can produce `__vite_ssr_exportName__ is not defined` or “Element type is invalid... got: undefined” (see “Why frontend tests fail” above).  
-We added a workaround in `src/test/setup.ts` that defines an SSR export helper; it only partly mitigates the issue. If you still see errors:
-
-1. **Practical option: use Vite 5 for tests**  
-   In `frontend/package.json`, temporarily set `vite` and `overrides.vite` to `"^5.4.11"`, run `npm install`, then `npm run test:run` so that frontend component tests run correctly.
-2. **Later:** Check Vitest/Vite docs for options to use “web” mode or disable SSR transform for tests (e.g. `transformMode`, a separate `vitest.config.ts`), then add the right config and try again with Vite 8.
-
-Do not rely on “Vite 8 fixing it”; the root cause may be environment/configuration, and there may be no official fix.  
-The **smoke test** (`src/test/smoke.test.ts`) only checks that the test environment runs and does not load React components, so it passes in the current setup.
+| File | Tests | Status |
+|------|-------|--------|
+| `src/test/smoke.test.ts` | 1 | ✅ Pass |
+| `src/app/pages/login-page.test.tsx` | 5 | ✅ Pass |
+| `src/app/pages/register-page.test.tsx` | 6 | ✅ Pass |
+| `src/app/pages/__tests__/group-detail-page.test.tsx` | 1 | ✅ Pass |
+| `src/app/pages/__tests__/swipe-page.test.tsx` | 2 | ✅ Pass |
+| `src/app/components/__tests__/restaurant-card.test.tsx` | 4 | ✅ Pass |
+| **Total** | **20** | **✅ All pass** |
 
 ---
 
 ## User story vs test coverage
 
-Below is how each user story maps to backend and frontend tests. **✅** = covered by tests; **⚠️** = partially covered or not implemented; **—** = not applicable or no test added.
+Below is how each user story maps to backend and frontend tests. **✅** = covered; **⚠️** = partial or not yet implemented; **—** = not applicable.
 
 ### User registration (email + password)
 
@@ -95,51 +89,42 @@ Below is how each user story maps to backend and frontend tests. **✅** = cover
 |------------|--------------|---------------|
 | Registration UI (email, password, confirm password) | — | ✅ `RegisterPage`: account step fields (name, email, password, confirm) |
 | Validate: email format | ✅ `test_registration_invalid_email` | ✅ invalid email validation |
-| Validate: password strength rules | ✅ Django form (e.g. in duplicate/invalid tests) | ✅ password length ≥ 6, passwords match |
+| Validate: password strength rules | ✅ Django validators | ✅ password length ≥ 8, passwords match |
 | Backend endpoint to create account | ✅ `test_registration_success` | — |
-| Hash password before storing | ✅ `test_registration_success` (assert not plaintext, `check_password`) | — |
-| Prevent duplicate accounts (email uniqueness) | ✅ `test_registration_duplicate_email` | ✅ API error (e.g. “already exists”) |
-| Neutral success + error responses | ✅ 200 + `success`/`user`; 400 + `errors` | ✅ error message display |
-| Auto-login after register | ✅ `test_registration_success` (session has `_auth_user_id`) | — (navigate to home in app) |
+| Hash password before storing | ✅ `test_registration_success` (`check_password`) | — |
+| Prevent duplicate accounts | ✅ `test_registration_duplicate_email` | ✅ API error display |
+| Auto-login after register | ✅ `test_registration_success` (session `_auth_user_id`) | — (navigate to home in app) |
 
 ### Login and logout
 
 | User story | Backend test | Frontend test |
 |------------|--------------|---------------|
-| Login UI and API call | ✅ `test_login_success`, `test_login_method_not_allowed` | ✅ form render, submit (mocked API) |
-| Secure session | ✅ session after login; `test_get_current_user_authenticated` | — |
-| Logout clears local auth state and invalidates session | ✅ `test_logout_behavior` (session cleared, me → 401) | — |
-| Rate limiting / brute-force mitigation | ✅ `LoginRateLimitTests` (429 after 10 failures, success resets) | — |
-| Proper error handling | ✅ `test_login_invalid_credentials` (401, no session) | ✅ invalid credentials error message |
+| Login UI and API call | ✅ `test_login_success` | ✅ form render, submit (mocked API) |
+| Secure session | ✅ session after login | — |
+| Logout clears session | ✅ `test_logout_behavior` | — |
+| Rate limiting | ✅ `LoginRateLimitTests` (429 after 10 failures) | — |
+| Proper error handling | ✅ `test_login_invalid_credentials` (401) | ✅ invalid credentials message |
 
 ### Login status (current user)
 
 | User story | Backend test | Frontend test |
 |------------|--------------|---------------|
-| “Get current user” endpoint | ✅ `test_get_current_user_authenticated`, `test_get_current_user_unauthenticated` | — |
-| On app load / post-login, fetch current user | — | Implemented in app context; ✅ covered indirectly via login flow |
-| Store user session client-side safely | — | Implemented (context + storage); no dedicated test |
-| Display user details (e.g. name) in profile | — | ⚠️ Implemented on home/profile; no separate test yet (add when Vite 8 fixed) |
-| Handle expired session (e.g. redirect to login) | ✅ unauthenticated → 401 from `api_me` | ⚠️ App uses 401 to clear user; redirect in app, not asserted in current tests |
+| "Get current user" endpoint | ✅ authenticated + unauthenticated cases | — |
+| On app load, fetch current user | — | Covered indirectly via login flow |
+| Handle expired session | ✅ unauthenticated → 401 | ⚠️ App redirects on 401; not directly tested |
 
 ### Password reset request (email form)
 
 | User story | Backend test | Frontend test |
 |------------|--------------|---------------|
-| Client- and server-side email validation | ✅ `test_password_reset_request_invalid_email`, `test_password_reset_request_missing_email` | ✅ forgot-password: submit without email, success with email |
-| Neutral success message | ✅ `test_password_reset_request_success` (message contains “account”) | ✅ “Check your email” after submit |
-| Error handling and design | ✅ 400 for invalid/missing; GET → 405 | ✅ validation error in dialog |
+| Email validation | ✅ invalid/missing email → 400 | ✅ forgot-password dialog validation |
+| Neutral success message | ✅ message contains "account" | ✅ "Check your email" after submit |
 
-### Password reset flow (set new password via token)
+### Password reset confirm (set new password via token)
 
 | User story | Backend test | Frontend test |
 |------------|--------------|---------------|
-| Reset request form + neutral message | ✅ See above | ✅ See above |
-| Backend creates time-limited reset token and sends email | ⚠️ **Not implemented** (API returns neutral message only; no token/email yet) | — |
-| Reset page accepts token + new password | ⚠️ **No API endpoint** for reset confirm in `api_urls` | — |
-| Enforce password rules and hash new password | — (no confirm endpoint) | — |
-| Prevent token reuse | — (no confirm endpoint) | — |
-| Rate limit reset requests | ⚠️ Not implemented in backend | — |
-| Avoid account enumeration | ✅ Neutral message on request | — |
-
-**Summary:** All **implemented** behaviour in the user stories is covered by the current backend and frontend tests. Gaps are (1) **password reset confirm** (token + new password) and **sending reset email / rate limiting reset** are not implemented in the backend, so there are no tests for them; (2) **profile display** and **expired-session redirect** are implemented in the app but not yet covered by frontend tests (good candidates once the Vite 8 test environment is fixed).
+| Token validation endpoint | ✅ valid/invalid token → 200/400 | — |
+| Reset confirm endpoint | ✅ valid token + password → 200 | — |
+| Weak password rejected | ✅ → 400 | — |
+| Rate limit reset requests | ⚠️ Not implemented | — |

--- a/docs/TEST_RESULTS.md
+++ b/docs/TEST_RESULTS.md
@@ -19,7 +19,7 @@ The chunk size warning from `npm run build` is expected for this bundle size. It
 
 **Suite:** `backend/tests/test_auth_integration.py`
 **Run from:** `backend/` directory
-**Command:** `python manage.py test tests.test_auth_integration -v 2`
+**Command:** `python manage.py test tests.test_auth_integration --settings=config.test_settings -v 2`
 
 ### Summary
 
@@ -39,7 +39,7 @@ The chunk size warning from `npm run build` is expected for this bundle size. It
 
 **Suite:** `backend/accounts/tests.py` — `CSRFProtectionTests`
 **Run from:** `backend/` directory
-**Command:** `python manage.py test accounts.CSRFProtectionTests -v 2`
+**Command:** `python manage.py test accounts.CSRFProtectionTests --settings=config.test_settings -v 2`
 
 These tests use `Client(enforce_csrf_checks=True)` to verify that all
 state-changing endpoints enforce Django's CSRF middleware after removing
@@ -72,10 +72,11 @@ Use the full test path (Django expects the first segment to be an app name; we u
 
 ```sh
 cd backend
-python manage.py test tests.test_auth_integration.AuthIntegrationTests.test_login_success -v 2
+python manage.py test tests.test_auth_integration.AuthIntegrationTests.test_login_success \
+  --settings=config.test_settings -v 2
 
 # Run the full CSRF suite (lives in the accounts app):
-python manage.py test accounts.CSRFProtectionTests -v 2
+python manage.py test accounts.CSRFProtectionTests --settings=config.test_settings -v 2
 ```
 
 ---

--- a/docs/TEST_RESULTS.md
+++ b/docs/TEST_RESULTS.md
@@ -17,9 +17,9 @@ The chunk size warning from `npm run build` is expected for this bundle size. It
 
 ## Backend: Authentication integration tests
 
-**Suite:** `backend/tests/test_auth_integration.py`
+**Suite:** `backend/accounts/tests.py` — `AuthIntegrationTests`
 **Run from:** `backend/` directory
-**Command:** `python manage.py test tests.test_auth_integration --settings=config.test_settings -v 2`
+**Command:** `python manage.py test accounts.tests.AuthIntegrationTests --settings=config.test_settings -v 2`
 
 ### Summary
 
@@ -39,7 +39,7 @@ The chunk size warning from `npm run build` is expected for this bundle size. It
 
 **Suite:** `backend/accounts/tests.py` — `CSRFProtectionTests`
 **Run from:** `backend/` directory
-**Command:** `python manage.py test accounts.CSRFProtectionTests --settings=config.test_settings -v 2`
+**Command:** `python manage.py test accounts.tests.CSRFProtectionTests --settings=config.test_settings -v 2`
 
 These tests use `Client(enforce_csrf_checks=True)` to verify that all
 state-changing endpoints enforce Django's CSRF middleware after removing
@@ -68,15 +68,15 @@ all `@csrf_exempt` decorators in WS1.
 
 ### Running a single test
 
-Use the full test path (Django expects the first segment to be an app name; we use `tests`):
+Use the full test path (Django expects the first segment to be an app name):
 
 ```sh
 cd backend
-python manage.py test tests.test_auth_integration.AuthIntegrationTests.test_login_success \
+python manage.py test accounts.tests.AuthIntegrationTests.test_login_success \
   --settings=config.test_settings -v 2
 
-# Run the full CSRF suite (lives in the accounts app):
-python manage.py test accounts.CSRFProtectionTests --settings=config.test_settings -v 2
+# Run the full CSRF suite:
+python manage.py test accounts.tests.CSRFProtectionTests --settings=config.test_settings -v 2
 ```
 
 ---

--- a/docs/TEST_RESULTS.md
+++ b/docs/TEST_RESULTS.md
@@ -55,7 +55,7 @@ all `@csrf_exempt` decorators in WS1.
 | `POST /api/auth/logout/`         | 403           | 200        | ✅ Pass    |
 | `PATCH /api/auth/preferences/`   | 403           | 200        | ✅ Pass    |
 | `POST /api/auth/request-password-reset/` | 403   | 200        | ✅ Pass    |
-| **Total**                        | **6 reject**  | **5 accept**| **✅ All pass** |
+| **Total**                        | **5 reject**  | **5 accept**| **✅ All pass** |
 
 ### Coverage by feature
 

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,73 +1,70 @@
-# React + TypeScript + Vite
+# MealSwipe — Frontend
 
-This template provides a minimal setup to get React working in Vite with HMR and some ESLint rules.
+React 19 + TypeScript + Vite 8 SPA for the MealSwipe application.
 
-Currently, two official plugins are available:
+## Stack
 
-- [@vitejs/plugin-react](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react) uses [Babel](https://babeljs.io/) (or [oxc](https://oxc.rs) when used in [rolldown-vite](https://vite.dev/guide/rolldown)) for Fast Refresh
-- [@vitejs/plugin-react-swc](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react-swc) uses [SWC](https://swc.rs/) for Fast Refresh
+- **React 19** with TypeScript
+- **Vite 8** (Rolldown-based) for bundling and dev server
+- **Tailwind CSS v4** for styling
+- **shadcn/ui** component library (Radix UI primitives)
+- **React Router v7** for client-side routing
+- **Sonner** for toast notifications
+- **Vitest** + **React Testing Library** for unit/integration tests
 
-## React Compiler
+## Quick start
 
-The React Compiler is not enabled on this template because of its impact on dev & build performances. To add it, see [this documentation](https://react.dev/learn/react-compiler/installation).
-
-## Expanding the ESLint configuration
-
-If you are developing a production application, we recommend updating the configuration to enable type-aware lint rules:
-
-```js
-export default defineConfig([
-  globalIgnores(['dist']),
-  {
-    files: ['**/*.{ts,tsx}'],
-    extends: [
-      // Other configs...
-
-      // Remove tseslint.configs.recommended and replace with this
-      tseslint.configs.recommendedTypeChecked,
-      // Alternatively, use this for stricter rules
-      tseslint.configs.strictTypeChecked,
-      // Optionally, add this for stylistic rules
-      tseslint.configs.stylisticTypeChecked,
-
-      // Other configs...
-    ],
-    languageOptions: {
-      parserOptions: {
-        project: ['./tsconfig.node.json', './tsconfig.app.json'],
-        tsconfigRootDir: import.meta.dirname,
-      },
-      // other options...
-    },
-  },
-])
+```sh
+cd frontend
+npm install
+npm run dev        # http://localhost:5173
 ```
 
-You can also install [eslint-plugin-react-x](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-x) and [eslint-plugin-react-dom](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-dom) for React-specific lint rules:
+API requests are proxied to the backend at `http://127.0.0.1:8000` via
+`VITE_API_BASE_URL` (see `frontend/.env.development`). For a local override
+create `frontend/.env.local` (gitignored) with:
 
-```js
-// eslint.config.js
-import reactX from 'eslint-plugin-react-x'
-import reactDom from 'eslint-plugin-react-dom'
-
-export default defineConfig([
-  globalIgnores(['dist']),
-  {
-    files: ['**/*.{ts,tsx}'],
-    extends: [
-      // Other configs...
-      // Enable lint rules for React
-      reactX.configs['recommended-typescript'],
-      // Enable lint rules for React DOM
-      reactDom.configs.recommended,
-    ],
-    languageOptions: {
-      parserOptions: {
-        project: ['./tsconfig.node.json', './tsconfig.app.json'],
-        tsconfigRootDir: import.meta.dirname,
-      },
-      // other options...
-    },
-  },
-])
 ```
+VITE_API_BASE_URL=http://127.0.0.1:8000
+```
+
+## Scripts
+
+| Command | Description |
+|---------|-------------|
+| `npm run dev` | Start dev server with HMR |
+| `npm run build` | Production build to `dist/` |
+| `npm run lint` | ESLint check |
+| `npm run test` | Vitest in watch mode |
+| `npm run test:run` | Single-run tests (CI) |
+| `npm run preview` | Serve the production build locally |
+
+## Project structure
+
+```
+src/
+├── app/
+│   ├── components/        # Shared UI components
+│   │   └── ui/            # shadcn/ui primitives
+│   ├── contexts/
+│   │   ├── auth-context.tsx   # Auth state (login, logout, register…)
+│   │   ├── app-context.tsx    # Domain state (groups, swipes, chat…)
+│   │   ├── venue-context.tsx  # Venue manager session
+│   │   └── admin-context.tsx  # Admin session
+│   ├── lib/
+│   │   └── api.ts         # Shared apiUrl() and getCsrf() helpers
+│   ├── pages/             # Route-level page components
+│   ├── layouts/           # Layout wrappers (root, auth, venue…)
+│   └── data/              # Static JSON data (preference options)
+└── test/                  # Vitest setup
+```
+
+## Testing
+
+```sh
+npm run test:run   # 6 files, 20 tests — all pass
+npm run lint       # ESLint — clean
+npm run build      # Vite build — succeeds (~758 kB bundle)
+```
+
+The chunk-size warning from `npm run build` is expected and is not an error.

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,10 +1,10 @@
 # MealSwipe — Frontend
 
-React 19 + TypeScript + Vite 8 SPA for the MealSwipe application.
+React 18 + TypeScript + Vite SPA for the MealSwipe application.
 
 ## Stack
 
-- **React 19** with TypeScript
+- **React 18** with TypeScript
 - **Vite 8** (Rolldown-based) for bundling and dev server
 - **Tailwind CSS v4** for styling
 - **shadcn/ui** component library (Radix UI primitives)

--- a/frontend/src/app/contexts/admin-context.tsx
+++ b/frontend/src/app/contexts/admin-context.tsx
@@ -1,18 +1,5 @@
 import { createContext, useContext, useEffect, useState, type ReactNode } from 'react';
-
-const API_BASE_URL = import.meta.env.VITE_API_BASE_URL ?? 'http://127.0.0.1:8000';
-
-function apiUrl(path: string) {
-  const normalizedPath = path.startsWith('/') ? path : `/${path}`;
-  return `${API_BASE_URL}${normalizedPath}`;
-}
-
-function getCookie(name: string): string {
-  const value = `; ${document.cookie}`;
-  const parts = value.split(`; ${name}=`);
-  if (parts.length === 2) return parts.pop()?.split(';').shift() ?? '';
-  return '';
-}
+import { apiUrl, getCsrf } from '@/app/lib/api';
 
 export interface AdminUser {
   id: string;
@@ -73,7 +60,7 @@ export function AdminProvider({ children }: { children: ReactNode }) {
   }, []);
 
   const loginAdmin = async (email: string, password: string) => {
-    const csrftoken = getCookie('csrftoken') || '';
+    const csrftoken = getCsrf();
     const response = await fetch(apiUrl('/api/auth/admin-login/'), {
       method: 'POST',
       credentials: 'include',
@@ -98,7 +85,7 @@ export function AdminProvider({ children }: { children: ReactNode }) {
     firstName: string;
     lastName: string;
   }) => {
-    const csrftoken = getCookie('csrftoken') || '';
+    const csrftoken = getCsrf();
     const response = await fetch(apiUrl('/api/auth/admin-register/'), {
       method: 'POST',
       credentials: 'include',
@@ -114,7 +101,7 @@ export function AdminProvider({ children }: { children: ReactNode }) {
   };
 
   const logoutAdmin = async () => {
-    const csrftoken = getCookie('csrftoken') || '';
+    const csrftoken = getCsrf();
     await fetch(apiUrl('/api/auth/logout/'), {
       method: 'POST',
       credentials: 'include',
@@ -124,7 +111,7 @@ export function AdminProvider({ children }: { children: ReactNode }) {
   };
 
   const requestAdminPasswordReset = async (email: string) => {
-    const csrftoken = getCookie('csrftoken') || '';
+    const csrftoken = getCsrf();
     const response = await fetch(apiUrl('/api/auth/admin-request-password-reset/'), {
       method: 'POST',
       credentials: 'include',
@@ -138,7 +125,7 @@ export function AdminProvider({ children }: { children: ReactNode }) {
   };
 
   const validateAdminPasswordResetToken = async (uid: string, token: string) => {
-    const csrftoken = getCookie('csrftoken') || '';
+    const csrftoken = getCsrf();
     const response = await fetch(apiUrl('/api/auth/validate-password-reset-token/'), {
       method: 'POST',
       credentials: 'include',
@@ -156,7 +143,7 @@ export function AdminProvider({ children }: { children: ReactNode }) {
     token: string,
     newPassword: string
   ) => {
-    const csrftoken = getCookie('csrftoken') || '';
+    const csrftoken = getCsrf();
     const response = await fetch(apiUrl('/api/auth/confirm-password-reset/'), {
       method: 'POST',
       credentials: 'include',

--- a/frontend/src/app/contexts/app-context.tsx
+++ b/frontend/src/app/contexts/app-context.tsx
@@ -1,65 +1,32 @@
+/**
+ * App context — groups, swipe events, chat, invitations, and notifications.
+ *
+ * Auth state (currentUser, login, logout, etc.) lives in AuthProvider
+ * (auth-context.tsx) which AppProvider composes internally. useApp() still
+ * returns the full merged interface so no component changes are needed.
+ */
 import { createContext, useContext, useState, useEffect, useCallback } from 'react';
 import type { ReactNode } from 'react';
 import type { Restaurant } from '@/app/data/mock-restaurants';
+import { apiUrl, getCsrf } from '@/app/lib/api';
+import {
+  AuthProvider,
+  useAuth,
+  normalizeApiUser,
+  type User,
+  type AuthContextType,
+} from './auth-context';
 
-const DEFAULT_PREFERENCES = {
-  cuisines: [] as string[],
-  dietary: [] as string[],
-  foodTypes: [] as string[],
-  minimumSanitationGrade: 'A' as string,
-};
-
-export interface User {
-  id: string;
-  name: string;
-  email: string;
-  role?: 'student' | 'venue_manager' | 'admin';
-  preferences: {
-    cuisines: string[];
-    dietary: string[];
-    foodTypes: string[];
-    minimumSanitationGrade?: string;
-  };
-  is_invited?: boolean;
-}
-
-/** Normalize API user payload to User (fill missing/partial preferences). */
+// ---------------------------------------------------------------------------
+// Re-export User so existing imports from app-context still work
+// ---------------------------------------------------------------------------
 // eslint-disable-next-line react-refresh/only-export-components
-export function normalizeApiUser(apiUser: {
-  id: number | string;
-  email: string;
-  name: string;
-  role?: 'student' | 'venue_manager' | 'admin';
-  preferences?: {
-    dietary?: string[];
-    cuisines?: string[];
-    foodTypes?: string[];
-    minimum_sanitation_grade?: string;
-  };
-  is_invited?: boolean;
-}): User {
-  const prefs = apiUser.preferences ?? {};
-  const grade = prefs.minimum_sanitation_grade ?? 'A';
-  return {
-    id: String(apiUser.id),
-    email: apiUser.email,
-    name: apiUser.name,
-    role: apiUser.role,
-    preferences: {
-      cuisines: Array.isArray(prefs.cuisines)
-        ? prefs.cuisines
-        : DEFAULT_PREFERENCES.cuisines,
-      dietary: Array.isArray(prefs.dietary)
-        ? prefs.dietary
-        : DEFAULT_PREFERENCES.dietary,
-      foodTypes: Array.isArray(prefs.foodTypes)
-        ? prefs.foodTypes
-        : DEFAULT_PREFERENCES.foodTypes,
-      minimumSanitationGrade: grade,
-    },
-    is_invited: apiUser.is_invited,
-  };
-}
+export { normalizeApiUser };
+export type { User };
+
+// ---------------------------------------------------------------------------
+// Domain types
+// ---------------------------------------------------------------------------
 
 export interface GroupMember {
   userId: string;
@@ -114,8 +81,8 @@ export interface ChatMessage {
 
 export interface DMConversation {
   id: string;
-  participants: string[]; // array of user IDs
-  participantNames: string[]; // array of user names
+  participants: string[];
+  participantNames: string[];
   lastMessageTime: string;
 }
 
@@ -138,19 +105,7 @@ export interface SwipeNotification {
   is_read: boolean;
 }
 
-interface RegisterData {
-  first_name: string;
-  last_name: string;
-  email: string;
-  password: string;
-  preferences?: {
-    cuisines?: string[];
-    dietary?: string[];
-    foodTypes?: string[];
-    minimum_sanitation_grade?: string;
-  };
-}
-
+// Internal backend shapes
 interface BackendMember {
   id: number | string;
   name: string;
@@ -173,40 +128,19 @@ interface BackendUser {
   name: string;
 }
 
-interface AppContextType {
-  currentUser: User | null;
-  login: (email: string, password: string) => Promise<void>;
-  register: (data: RegisterData) => Promise<void>;
-  logout: () => Promise<void>;
-  requestPasswordReset: (email: string) => Promise<void>;
-  validatePasswordResetToken: (uid: string, token: string) => Promise<void>;
-  confirmPasswordReset: (
-    uid: string,
-    token: string,
-    newPassword: string
-  ) => Promise<void>;
-  updatePreferences: (preferences: {
-    dietary?: string[];
-    cuisines?: string[];
-    foodTypes?: string[];
-    minimumSanitationGrade?: string;
-  }) => Promise<void>;
+// ---------------------------------------------------------------------------
+// Context type — auth fields + app fields, same public surface as before
+// ---------------------------------------------------------------------------
+
+export interface AppContextType extends AuthContextType {
   groups: Group[];
-  createGroup: (
-    name: string,
-    groupType?: string,
-    defaultLocation?: string,
-    privacy?: string
-  ) => Promise<Group>;
+  createGroup: (name: string, groupType?: string, defaultLocation?: string, privacy?: string) => Promise<Group>;
   joinGroup: (code: string) => Promise<void>;
   fetchPublicGroups: () => Promise<Group[]>;
   regenerateJoinCode: (groupId: string) => Promise<string>;
   leaveGroup: (groupId: string) => Promise<void>;
   deleteGroup: (groupId: string) => Promise<void>;
-  updateGroupConstraints: (
-    groupId: string,
-    constraints: GroupConstraints
-  ) => Promise<void>;
+  updateGroupConstraints: (groupId: string, constraints: GroupConstraints) => Promise<void>;
   removeMember: (groupId: string, userId: string) => Promise<void>;
   makeLeader: (groupId: string, userId: string) => Promise<void>;
   inviteMember: (groupId: string, userEmail: string) => Promise<void>;
@@ -216,34 +150,21 @@ interface AppContextType {
   currentGroup: Group | null;
   setCurrentGroup: (group: Group | null) => void;
   swipeEvents: SwipeEvent[];
-  createSwipeEvent: (
-    groupId: string,
-    name: string,
-    borough?: string,
-    neighborhood?: string
-  ) => Promise<SwipeEvent>;
+  createSwipeEvent: (groupId: string, name: string, borough?: string, neighborhood?: string) => Promise<SwipeEvent>;
   fetchSwipeEvents: (groupId: string, signal?: AbortSignal) => Promise<void>;
   currentSwipeEvent: SwipeEvent | null;
   setCurrentSwipeEvent: (event: SwipeEvent | null) => void;
-  swipes: Record<string, Swipe[]>; // eventId -> swipes
-  addSwipe: (
-    eventId: string,
-    groupId: string,
-    venueId: string,
-    direction: 'left' | 'right'
-  ) => Promise<void>;
+  swipes: Record<string, Swipe[]>;
+  addSwipe: (eventId: string, groupId: string, venueId: string, direction: 'left' | 'right') => Promise<void>;
   fetchSwipeVenues: (groupId: string, eventId: string) => Promise<Restaurant[]>;
-  fetchMatchResults: (
-    groupId: string,
-    eventId: string
-  ) => Promise<{
+  fetchMatchResults: (groupId: string, eventId: string) => Promise<{
     match_found: boolean;
     matched_venue: Restaurant | null;
     total_participants: number;
     threshold: number;
     likes_count: number;
   }>;
-  chatMessages: Record<string, ChatMessage[]>; // groupId or dmId -> messages
+  chatMessages: Record<string, ChatMessage[]>;
   addChatMessage: (conversationId: string, message: ChatMessage) => Promise<void>;
   deleteChatMessage: (conversationId: string, messageId: string) => Promise<void>;
   chatMutedParticipants: Record<string, string[]>;
@@ -251,11 +172,7 @@ interface AppContextType {
   openUserDM: (userId: string) => Promise<void>;
   dmConversations: DMConversation[];
   createDMConversation: (participantId: string) => Promise<DMConversation>;
-  updateSwipeEventStatus: (
-    eventId: string,
-    status: SwipeEvent['status'],
-    matchedId?: string
-  ) => void;
+  updateSwipeEventStatus: (eventId: string, status: SwipeEvent['status'], matchedId?: string) => void;
   invitations: Invitation[];
   swipeNotifications: SwipeNotification[];
   fetchInvitations: () => Promise<void>;
@@ -266,32 +183,14 @@ interface AppContextType {
 
 const AppContext = createContext<AppContextType | undefined>(undefined);
 
-// CSRF token helper
-function getCookie(name: string) {
-  let cookieValue = null;
-  if (document.cookie && document.cookie !== '') {
-    const cookies = document.cookie.split(';');
-    for (let i = 0; i < cookies.length; i++) {
-      const cookie = cookies[i].trim();
-      if (cookie.substring(0, name.length + 1) === name + '=') {
-        cookieValue = decodeURIComponent(cookie.substring(name.length + 1));
-        break;
-      }
-    }
-  }
-  return cookieValue;
-}
+// ---------------------------------------------------------------------------
+// AppInner — sits inside AuthProvider, can call useAuth()
+// ---------------------------------------------------------------------------
 
-const API_BASE_URL = import.meta.env.VITE_API_BASE_URL ?? 'http://127.0.0.1:8000';
+function AppInner({ children }: { children: ReactNode }) {
+  const auth = useAuth();
+  const { currentUser } = auth;
 
-function apiUrl(path: string) {
-  const normalizedPath = path.startsWith('/') ? path : `/${path}`;
-  return `${API_BASE_URL}${normalizedPath}`;
-}
-
-export function AppProvider({ children }: { children: ReactNode }) {
-  const [currentUser, setCurrentUser] = useState<User | null>(null);
-  const [isInitializingAuth, setIsInitializingAuth] = useState(true);
   const [groups, setGroups] = useState<Group[]>([]);
   const [availableUsers, setAvailableUsers] = useState<User[]>([]);
   const [currentGroup, setCurrentGroup] = useState<Group | null>(null);
@@ -300,81 +199,64 @@ export function AppProvider({ children }: { children: ReactNode }) {
   const [swipes] = useState<Record<string, Swipe[]>>({});
   const [chatMessages, setChatMessages] = useState<Record<string, ChatMessage[]>>({});
   const [dmConversations, setDMConversations] = useState<DMConversation[]>([]);
-  const [chatMutedParticipants, setChatMutedParticipants] = useState<
-    Record<string, string[]>
-  >({});
+  const [chatMutedParticipants, setChatMutedParticipants] = useState<Record<string, string[]>>({});
   const [invitations, setInvitations] = useState<Invitation[]>([]);
   const [swipeNotifications, setSwipeNotifications] = useState<SwipeNotification[]>([]);
 
-  // Clean up legacy localStorage demo data left from older versions of the app.
-  // This runs once on mount — it does not seed anything new.
+  // Clean up legacy localStorage keys left by older versions of this app.
   useEffect(() => {
     const LEGACY_KEYS = [
-      'mealswipe_seeded',
-      'mealswipe_version',
-      'mealswipe_groups',
-      'mealswipe_events',
-      'mealswipe_swipes',
-      'mealswipe_messages',
-      'mealswipe_notifications',
-      'mealswipe_dm_conversations',
-      'mealswipe_user',
+      'mealswipe_seeded', 'mealswipe_version', 'mealswipe_groups',
+      'mealswipe_events', 'mealswipe_swipes', 'mealswipe_messages',
+      'mealswipe_notifications', 'mealswipe_dm_conversations', 'mealswipe_user',
     ];
     LEGACY_KEYS.forEach((k) => localStorage.removeItem(k));
   }, []);
 
-
-
   // ---------------------------------------------------------------------------
-  // ACTUAL API AUTHENTICATION LOGIC (Django Session Auth)
+  // Data fetch helpers — called when session becomes active
   // ---------------------------------------------------------------------------
 
-  const fetchUserGroups = async () => {
+  const fetchUserGroups = useCallback(async () => {
     try {
-      const groupsResponse = await fetch(apiUrl('/api/groups/'), {
-        credentials: 'include',
-      });
-      if (groupsResponse.ok) {
-        const groupsData = await groupsResponse.json();
-        const mappedGroups = groupsData.groups.map((g: BackendGroup) => ({
-          id: String(g.id),
-          name: g.name,
-          members: g.members.map((m: BackendMember) => ({
-            userId: String(m.id),
-            userName: m.name,
-            hasFinishedSwiping: false, // UI abstraction
-            isLeader: m.role === 'leader',
-          })),
-          createdBy: String(g.created_by),
-          createdAt: g.created_at,
-          joinCode: g.join_code,
-          constraints: g.constraints,
-        }));
-        setGroups(mappedGroups);
+      const res = await fetch(apiUrl('/api/groups/'), { credentials: 'include' });
+      if (res.ok) {
+        const data = await res.json();
+        setGroups(
+          data.groups.map((g: BackendGroup) => ({
+            id: String(g.id),
+            name: g.name,
+            members: g.members.map((m: BackendMember) => ({
+              userId: String(m.id),
+              userName: m.name,
+              hasFinishedSwiping: false,
+              isLeader: m.role === 'leader',
+            })),
+            createdBy: String(g.created_by),
+            createdAt: g.created_at,
+            joinCode: g.join_code,
+            constraints: g.constraints,
+          }))
+        );
       }
     } catch (err) {
       console.error('Failed to fetch user groups', err);
     }
-  };
+  }, []);
 
-  const fetchUserChats = async () => {
+  const fetchUserChats = useCallback(async () => {
     try {
-      const response = await fetch(apiUrl('/api/chat/'), {
-        credentials: 'include',
-      });
-      if (response.ok) {
-        const data = await response.json();
-        const chats = data.chats;
-
-        const newChatMessages: Record<string, ChatMessage[]> = {};
+      const res = await fetch(apiUrl('/api/chat/'), { credentials: 'include' });
+      if (res.ok) {
+        const data = await res.json();
+        const newMessages: Record<string, ChatMessage[]> = {};
         const dms: DMConversation[] = [];
-        const newMutedParticipants: Record<string, string[]> = {};
-
+        const muted: Record<string, string[]> = {};
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        chats.forEach((chat: any) => {
-          const msgKey = chat.type === 'direct' ? `dm-${chat.id}` : chat.id;
-          newChatMessages[msgKey] = chat.messages || [];
-          newMutedParticipants[chat.id] = chat.mutedParticipants || [];
+        data.chats.forEach((chat: any) => {
+          const key = chat.type === 'direct' ? `dm-${chat.id}` : chat.id;
+          newMessages[key] = chat.messages || [];
+          muted[chat.id] = chat.mutedParticipants || [];
           if (chat.type === 'direct') {
             dms.push({
               id: chat.id,
@@ -384,40 +266,71 @@ export function AppProvider({ children }: { children: ReactNode }) {
             });
           }
         });
-
-        setChatMessages(newChatMessages);
+        setChatMessages(newMessages);
         setDMConversations(dms);
-        setChatMutedParticipants(newMutedParticipants);
+        setChatMutedParticipants(muted);
       }
     } catch (err) {
       console.error('Failed to fetch user chats', err);
     }
-  };
+  }, []);
 
-  const fetchInvitations = async () => {
+  const fetchInvitations = useCallback(async () => {
     try {
-      const response = await fetch(apiUrl('/api/groups/invitations/'), {
-        credentials: 'include',
-      });
-      if (response.ok) {
-        const data = await response.json();
+      const res = await fetch(apiUrl('/api/groups/invitations/'), { credentials: 'include' });
+      if (res.ok) {
+        const data = await res.json();
         setInvitations(data.invitations || []);
         setSwipeNotifications(data.swipe_sessions || []);
       }
     } catch (err) {
       console.error('Failed to fetch invitations', err);
     }
-  };
+  }, []);
+
+  // Load data when user logs in; clear when they log out.
+  useEffect(() => {
+    if (currentUser) {
+      fetchUserGroups();
+      fetchUserChats();
+      fetchInvitations();
+    } else {
+      setGroups([]);
+      setSwipeEvents([]);
+      setChatMessages({});
+      setDMConversations([]);
+      setInvitations([]);
+      setSwipeNotifications([]);
+      setCurrentGroup(null);
+      setCurrentSwipeEvent(null);
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [currentUser?.id]);
+
+  // Short-poll for chat and notification updates while logged in.
+  useEffect(() => {
+    if (!currentUser) return;
+    const interval = setInterval(() => {
+      if (document.visibilityState === 'visible') {
+        fetchUserChats();
+        fetchInvitations();
+      }
+    }, 10000);
+    return () => clearInterval(interval);
+  }, [currentUser, fetchUserChats, fetchInvitations]);
+
+  // ---------------------------------------------------------------------------
+  // Invitations
+  // ---------------------------------------------------------------------------
 
   const acceptInvitation = async (id: string | number) => {
     try {
-      const csrftoken = getCookie('csrftoken') || '';
-      const response = await fetch(apiUrl(`/api/groups/invitations/${id}/accept/`), {
+      const res = await fetch(apiUrl(`/api/groups/invitations/${id}/accept/`), {
         method: 'POST',
-        headers: { 'X-CSRFToken': csrftoken },
+        headers: { 'X-CSRFToken': getCsrf() },
         credentials: 'include',
       });
-      if (response.ok) {
+      if (res.ok) {
         await fetchInvitations();
         await fetchUserGroups();
         await fetchUserChats();
@@ -429,15 +342,12 @@ export function AppProvider({ children }: { children: ReactNode }) {
 
   const declineInvitation = async (id: string | number) => {
     try {
-      const csrftoken = getCookie('csrftoken') || '';
-      const response = await fetch(apiUrl(`/api/groups/invitations/${id}/decline/`), {
+      const res = await fetch(apiUrl(`/api/groups/invitations/${id}/decline/`), {
         method: 'POST',
-        headers: { 'X-CSRFToken': csrftoken },
+        headers: { 'X-CSRFToken': getCsrf() },
         credentials: 'include',
       });
-      if (response.ok) {
-        await fetchInvitations();
-      }
+      if (res.ok) await fetchInvitations();
     } catch (err) {
       console.error('Failed to decline invitation', err);
     }
@@ -445,255 +355,20 @@ export function AppProvider({ children }: { children: ReactNode }) {
 
   const markSwipeNotificationRead = async (id: string | number) => {
     try {
-      const csrftoken = getCookie('csrftoken') || '';
-      const response = await fetch(
-        apiUrl(`/api/groups/swipe-notifications/${id}/read/`),
-        {
-          method: 'POST',
-          headers: { 'X-CSRFToken': csrftoken },
-          credentials: 'include',
-        }
-      );
-      if (response.ok) {
-        await fetchInvitations();
-      }
+      const res = await fetch(apiUrl(`/api/groups/swipe-notifications/${id}/read/`), {
+        method: 'POST',
+        headers: { 'X-CSRFToken': getCsrf() },
+        credentials: 'include',
+      });
+      if (res.ok) await fetchInvitations();
     } catch (err) {
       console.error('Failed to mark swipe notification read', err);
     }
   };
 
-  // Check session on mount
-  useEffect(() => {
-    const checkSession = async () => {
-      try {
-        // We use fetch so the browser automatically includes cookies
-        const response = await fetch(apiUrl('/api/auth/me/'), {
-          credentials: 'include',
-        });
-        if (response.ok) {
-          const data = await response.json();
-          if (data.authenticated && data.user) {
-            setCurrentUser(normalizeApiUser(data.user));
-            await fetchUserGroups();
-            await fetchUserChats();
-            await fetchInvitations();
-          }
-        }
-      } catch (error) {
-        console.error('Session check failed:', error);
-      } finally {
-        setIsInitializingAuth(false);
-      }
-    };
-    checkSession();
-  }, []);
-
-  // Short polling for chat updates
-  useEffect(() => {
-    if (!currentUser) return;
-    const interval = setInterval(() => {
-      // Basic optimization: only poll if document is visible
-      if (document.visibilityState === 'visible') {
-        // Background fetch without loading spin
-        fetchUserChats();
-        fetchInvitations();
-      }
-    }, 10000);
-    return () => clearInterval(interval);
-  }, [currentUser]);
-
-  const login = async (email: string, password: string) => {
-    try {
-      const csrftoken = getCookie('csrftoken') || '';
-      const response = await fetch(apiUrl('/api/auth/login/'), {
-        method: 'POST',
-        credentials: 'include',
-        headers: {
-          'Content-Type': 'application/json',
-          'X-CSRFToken': csrftoken,
-        },
-        body: JSON.stringify({ email, password }),
-      });
-
-      const data = await response.json();
-      if (response.ok && data.success) {
-        setCurrentUser(normalizeApiUser(data.user));
-        await fetchUserGroups();
-        await fetchUserChats();
-      } else {
-        throw new Error(data.error || 'Login failed');
-      }
-    } catch (error) {
-      console.error('Login error:', error);
-      throw error;
-    }
-  };
-
-  const updatePreferences = async (preferences: {
-    dietary?: string[];
-    cuisines?: string[];
-    foodTypes?: string[];
-    minimumSanitationGrade?: string;
-  }) => {
-    const csrftoken = getCookie('csrftoken') || '';
-    const body: Record<string, unknown> = {};
-    if (preferences.dietary !== undefined) body.dietary = preferences.dietary;
-    if (preferences.cuisines !== undefined) body.cuisines = preferences.cuisines;
-    if (preferences.foodTypes !== undefined) body.foodTypes = preferences.foodTypes;
-    if (preferences.minimumSanitationGrade !== undefined) {
-      body.minimum_sanitation_grade = preferences.minimumSanitationGrade;
-    }
-    const response = await fetch(apiUrl('/api/auth/preferences/'), {
-      method: 'PATCH',
-      credentials: 'include',
-      headers: {
-        'Content-Type': 'application/json',
-        'X-CSRFToken': csrftoken,
-      },
-      body: JSON.stringify(body),
-    });
-    if (!response.ok) {
-      const err = await response.json().catch(() => ({}));
-      throw new Error(
-        (err as { error?: string }).error || 'Failed to update preferences'
-      );
-    }
-    const data = await response.json();
-    if (data.user) setCurrentUser(normalizeApiUser(data.user));
-  };
-
-  const register = async (userData: RegisterData) => {
-    try {
-      const csrftoken = getCookie('csrftoken') || '';
-      const response = await fetch(apiUrl('/api/auth/register/'), {
-        method: 'POST',
-        credentials: 'include',
-        headers: {
-          'Content-Type': 'application/json',
-          'X-CSRFToken': csrftoken,
-        },
-        body: JSON.stringify(userData),
-      });
-
-      const data = await response.json();
-      if (response.ok && data.success) {
-        setCurrentUser(normalizeApiUser(data.user));
-        await fetchUserGroups();
-        await fetchUserChats();
-      } else {
-        let errorMessage = data.error || 'Registration failed';
-        if (data.errors && typeof data.errors === 'object') {
-          const firstKey = Object.keys(data.errors)[0];
-          if (firstKey && data.errors[firstKey]?.length > 0) {
-            errorMessage = data.errors[firstKey][0];
-          }
-        }
-        throw new Error(errorMessage);
-      }
-    } catch (error) {
-      console.error('Register error:', error);
-      throw error;
-    }
-  };
-
-  const requestPasswordReset = async (email: string) => {
-    try {
-      const csrftoken = getCookie('csrftoken') || '';
-      const response = await fetch(apiUrl('/api/auth/request-password-reset/'), {
-        method: 'POST',
-        credentials: 'include',
-        headers: {
-          'Content-Type': 'application/json',
-          'X-CSRFToken': csrftoken,
-        },
-        body: JSON.stringify({ email }),
-      });
-
-      const data = await response.json();
-      if (!response.ok || !data.success) {
-        throw new Error(data.error || 'Request failed');
-      }
-    } catch (error) {
-      console.error('Password reset error:', error);
-      throw error;
-    }
-  };
-
-  const validatePasswordResetToken = async (uid: string, token: string) => {
-    try {
-      const csrftoken = getCookie('csrftoken') || '';
-      const response = await fetch(apiUrl('/api/auth/validate-password-reset-token/'), {
-        method: 'POST',
-        credentials: 'include',
-        headers: {
-          'Content-Type': 'application/json',
-          'X-CSRFToken': csrftoken,
-        },
-        body: JSON.stringify({ uid, token }),
-      });
-
-      const data = await response.json();
-      if (!response.ok || !data.success || !data.valid) {
-        throw new Error(data.error || 'Invalid or expired reset link');
-      }
-    } catch (error) {
-      console.error('Password reset token validation error:', error);
-      throw error;
-    }
-  };
-
-  const confirmPasswordReset = async (
-    uid: string,
-    token: string,
-    newPassword: string
-  ) => {
-    try {
-      const csrftoken = getCookie('csrftoken') || '';
-      const response = await fetch(apiUrl('/api/auth/confirm-password-reset/'), {
-        method: 'POST',
-        credentials: 'include',
-        headers: {
-          'Content-Type': 'application/json',
-          'X-CSRFToken': csrftoken,
-        },
-        body: JSON.stringify({ uid, token, new_password: newPassword }),
-      });
-
-      const data = await response.json();
-      if (!response.ok || !data.success) {
-        throw new Error(data.error || 'Failed to reset password');
-      }
-    } catch (error) {
-      console.error('Password reset confirmation error:', error);
-      throw error;
-    }
-  };
-
-  const logout = async () => {
-    try {
-      const csrftoken = getCookie('csrftoken') || '';
-      await fetch(apiUrl('/api/auth/logout/'), {
-        method: 'POST',
-        credentials: 'include',
-        headers: {
-          'Content-Type': 'application/json',
-          'X-CSRFToken': csrftoken,
-        },
-      });
-      setCurrentUser(null);
-      setCurrentGroup(null);
-      setCurrentSwipeEvent(null);
-      setGroups([]);
-      setSwipeEvents([]);
-      setChatMessages({});
-      setDMConversations([]);
-      setInvitations([]);
-      setSwipeNotifications([]);
-    } catch (error) {
-      console.error('Logout error:', error);
-    }
-  };
-
+  // ---------------------------------------------------------------------------
+  // Groups
+  // ---------------------------------------------------------------------------
 
   const createGroup = async (
     name: string,
@@ -702,72 +377,41 @@ export function AppProvider({ children }: { children: ReactNode }) {
     privacy: string = 'public'
   ): Promise<Group> => {
     if (!currentUser) throw new Error('Must be logged in');
-
-    const csrftoken = getCookie('csrftoken') || '';
-    const response = await fetch(apiUrl('/api/groups/'), {
+    const res = await fetch(apiUrl('/api/groups/'), {
       method: 'POST',
       credentials: 'include',
-      headers: {
-        'Content-Type': 'application/json',
-        'X-CSRFToken': csrftoken,
-      },
-      body: JSON.stringify({
-        name,
-        group_type: groupType,
-        default_location: defaultLocation,
-        privacy,
-      }),
+      headers: { 'Content-Type': 'application/json', 'X-CSRFToken': getCsrf() },
+      body: JSON.stringify({ name, group_type: groupType, default_location: defaultLocation, privacy }),
     });
-
-    if (!response.ok) {
-      const err = await response.json().catch(() => ({}));
+    if (!res.ok) {
+      const err = await res.json().catch(() => ({}));
       throw new Error(err.error || 'Failed to create group');
     }
-
-    const data = await response.json();
-    const newGroupBackend = data.group;
-
-    // Map backend group format to frontend Group interface
+    const data = await res.json();
+    const bg = data.group;
     const newGroup: Group = {
-      id: String(newGroupBackend.id),
-      name: newGroupBackend.name,
-      members: newGroupBackend.members.map((m: BackendMember) => ({
+      id: String(bg.id),
+      name: bg.name,
+      members: bg.members.map((m: BackendMember) => ({
         userId: String(m.id),
         userName: m.name,
-        hasFinishedSwiping: false, // UI abstraction
+        hasFinishedSwiping: false,
         isLeader: m.role === 'leader',
       })),
-      createdBy: String(newGroupBackend.created_by),
-      createdAt: newGroupBackend.created_at,
-      joinCode: newGroupBackend.join_code,
-      constraints: newGroupBackend.constraints,
+      createdBy: String(bg.created_by),
+      createdAt: bg.created_at,
+      joinCode: bg.join_code,
+      constraints: bg.constraints,
     };
-
     setGroups((prev) => [...prev, newGroup]);
-
-    // Initialize chat for this group
-    setChatMessages((prev) => ({
-      ...prev,
-      [newGroup.id]: [
-        {
-          id: `msg-${Date.now()}`,
-          type: 'system',
-          message: `${currentUser.name} created the group`,
-          timestamp: new Date().toISOString(),
-        },
-      ],
-    }));
-
     return newGroup;
   };
 
   const fetchPublicGroups = async (): Promise<Group[]> => {
     try {
-      const response = await fetch(apiUrl('/api/groups/public/'), {
-        credentials: 'include',
-      });
-      const data = await response.json();
-      if (response.ok) {
+      const res = await fetch(apiUrl('/api/groups/public/'), { credentials: 'include' });
+      const data = await res.json();
+      if (res.ok) {
         return data.groups.map((g: BackendGroup) => ({
           id: String(g.id),
           name: g.name,
@@ -791,183 +435,66 @@ export function AppProvider({ children }: { children: ReactNode }) {
   };
 
   const joinGroup = async (code: string): Promise<void> => {
-    try {
-      const csrftoken = getCookie('csrftoken') || '';
-      const response = await fetch(apiUrl(`/api/groups/join/${code}/`), {
-        method: 'POST',
-        credentials: 'include',
-        headers: {
-          'X-CSRFToken': csrftoken,
-        },
-      });
-
-      const data = await response.json();
-      if (!response.ok) {
-        throw new Error(
-          data.error || 'Failed to join group. Make sure code is correct.'
-        );
-      }
-
-      // Update local state by re-fetching
-      await fetchUserGroups();
-      await fetchUserChats();
-    } catch (error) {
-      console.error('Join group error:', error);
-      throw error;
-    }
+    const res = await fetch(apiUrl(`/api/groups/join/${code}/`), {
+      method: 'POST',
+      credentials: 'include',
+      headers: { 'X-CSRFToken': getCsrf() },
+    });
+    const data = await res.json();
+    if (!res.ok) throw new Error(data.error || 'Failed to join group. Make sure code is correct.');
+    await fetchUserGroups();
+    await fetchUserChats();
   };
 
   const regenerateJoinCode = async (groupId: string): Promise<string> => {
-    try {
-      const csrftoken = getCookie('csrftoken') || '';
-      const response = await fetch(apiUrl(`/api/groups/${groupId}/regenerate-code/`), {
-        method: 'POST',
-        credentials: 'include',
-        headers: {
-          'X-CSRFToken': csrftoken,
-        },
-      });
-
-      const data = await response.json();
-      if (!response.ok) {
-        throw new Error(data.error || 'Failed to regenerate code');
-      }
-
-      // Update local state directly
-      setGroups(
-        groups.map((g) => (g.id === groupId ? { ...g, joinCode: data.join_code } : g))
-      );
-      return data.join_code;
-    } catch (error) {
-      console.error('Regenerate code error:', error);
-      throw error;
+    const res = await fetch(apiUrl(`/api/groups/${groupId}/regenerate-code/`), {
+      method: 'POST',
+      credentials: 'include',
+      headers: { 'X-CSRFToken': getCsrf() },
+    });
+    if (!res.ok) {
+      const err = await res.json().catch(() => ({}));
+      throw new Error(err.error || 'Failed to regenerate code');
     }
+    const data = await res.json();
+    const newCode: string = data.join_code;
+    setGroups((prev) =>
+      prev.map((g) => (g.id === groupId ? { ...g, joinCode: newCode } : g))
+    );
+    return newCode;
   };
 
   const leaveGroup = async (groupId: string): Promise<void> => {
     if (!currentUser) return;
-    try {
-      const csrftoken = getCookie('csrftoken') || '';
-      const response = await fetch(apiUrl(`/api/groups/${groupId}/leave/`), {
-        method: 'POST',
-        credentials: 'include',
-        headers: {
-          'X-CSRFToken': csrftoken,
-        },
-      });
-
-      if (!response.ok) {
-        const err = await response.json().catch(() => ({}));
-        throw new Error(err.error || 'Failed to leave group');
-      }
-
-      // Remove from local state
-      setGroups((prev) => prev.filter((g) => g.id !== groupId));
-
-      // Optional: add system message or navigate away in component
-    } catch (error) {
-      console.error('Leave group error:', error);
-      throw error;
+    const res = await fetch(apiUrl(`/api/groups/${groupId}/leave/`), {
+      method: 'POST',
+      credentials: 'include',
+      headers: { 'X-CSRFToken': getCsrf() },
+    });
+    if (!res.ok) {
+      const err = await res.json().catch(() => ({}));
+      throw new Error(err.error || 'Failed to leave group');
     }
+    setGroups((prev) => prev.filter((g) => g.id !== groupId));
+    if (currentGroup?.id === groupId) setCurrentGroup(null);
   };
 
   const deleteGroup = async (groupId: string): Promise<void> => {
     if (!currentUser) return;
-    try {
-      const csrftoken = getCookie('csrftoken') || '';
-      const response = await fetch(apiUrl(`/api/groups/${groupId}/delete/`), {
-        method: 'DELETE',
-        credentials: 'include',
-        headers: {
-          'X-CSRFToken': csrftoken,
-        },
-      });
-
-      if (!response.ok) {
-        const err = await response.json().catch(() => ({}));
-        throw new Error(err.error || 'Failed to delete group');
-      }
-
-      setGroups((prev) => prev.filter((g) => g.id !== groupId));
-      if (currentGroup?.id === groupId) {
-        setCurrentGroup(null);
-      }
-    } catch (error) {
-      console.error('Delete group error:', error);
-      throw error;
+    const res = await fetch(apiUrl(`/api/groups/${groupId}/`), {
+      method: 'DELETE',
+      credentials: 'include',
+      headers: { 'X-CSRFToken': getCsrf() },
+    });
+    if (!res.ok) {
+      const err = await res.json().catch(() => ({}));
+      throw new Error(err.error || 'Failed to delete group');
     }
+    setGroups((prev) => prev.filter((g) => g.id !== groupId));
+    if (currentGroup?.id === groupId) setCurrentGroup(null);
   };
 
-  const inviteMember = async (groupId: string, userEmail: string): Promise<void> => {
-    if (!currentUser) return;
-
-    try {
-      const csrftoken = getCookie('csrftoken') || '';
-      const response = await fetch(apiUrl(`/api/groups/${groupId}/invite/`), {
-        method: 'POST',
-        credentials: 'include',
-        headers: {
-          'Content-Type': 'application/json',
-          'X-CSRFToken': csrftoken,
-        },
-        body: JSON.stringify({ email: userEmail }),
-      });
-
-      if (!response.ok) {
-        const err = await response.json().catch(() => ({}));
-        throw new Error(err.error || 'Failed to invite user');
-      }
-
-      // Invitation sent successfully, nothing more to do locally since they aren't added to the group yet
-      // The pending invitation requires the other user to accept it.
-    } catch (error) {
-      console.error('Invite member error:', error);
-      throw error;
-    }
-  };
-
-  const removeMember = async (groupId: string, userId: string): Promise<void> => {
-    if (!currentUser) return;
-    try {
-      const csrftoken = getCookie('csrftoken') || '';
-      const response = await fetch(
-        apiUrl(`/api/groups/${groupId}/members/${userId}/`),
-        {
-          method: 'DELETE',
-          credentials: 'include',
-          headers: {
-            'X-CSRFToken': csrftoken,
-          },
-        }
-      );
-
-      if (!response.ok) {
-        const err = await response.json().catch(() => ({}));
-        throw new Error(err.error || 'Failed to remove member');
-      }
-
-      setGroups((prevGroups) =>
-        prevGroups.map((group) => {
-          if (group.id === groupId) {
-            return {
-              ...group,
-              members: group.members.filter((m) => m.userId !== userId),
-            };
-          }
-          return group;
-        })
-      );
-    } catch (error) {
-      console.error('Remove member error:', error);
-      throw error;
-    }
-  };
-
-  const updateGroupConstraints = async (
-    groupId: string,
-    constraints: GroupConstraints
-  ) => {
-    const csrftoken = getCookie('csrftoken') || '';
+  const updateGroupConstraints = async (groupId: string, constraints: GroupConstraints) => {
     const body: Record<string, unknown> = {};
     if (constraints.dietary !== undefined) body.dietary = constraints.dietary;
     if (constraints.cuisines !== undefined) body.cuisines = constraints.cuisines;
@@ -975,93 +502,96 @@ export function AppProvider({ children }: { children: ReactNode }) {
     if (constraints.minimumSanitationGrade !== undefined) {
       body.minimumSanitationGrade = constraints.minimumSanitationGrade;
     }
-    const response = await fetch(apiUrl(`/api/groups/${groupId}/constraints/`), {
+    const res = await fetch(apiUrl(`/api/groups/${groupId}/constraints/`), {
       method: 'PATCH',
       credentials: 'include',
-      headers: {
-        'Content-Type': 'application/json',
-        'X-CSRFToken': csrftoken,
-      },
+      headers: { 'Content-Type': 'application/json', 'X-CSRFToken': getCsrf() },
       body: JSON.stringify(body),
     });
-    if (!response.ok) {
-      const err = await response.json().catch(() => ({}));
+    if (!res.ok) {
+      const err = await res.json().catch(() => ({}));
       throw new Error(err.error || 'Failed to update constraints');
     }
-    const data = await response.json();
-    const updatedBg = data.group as BackendGroup;
+    const data = await res.json();
+    const updated = data.group as BackendGroup;
+    setGroups((prev) =>
+      prev.map((g) => (g.id === String(updated.id) ? { ...g, constraints: updated.constraints } : g))
+    );
+    if (currentGroup?.id === String(updated.id)) {
+      setCurrentGroup((prev) => (prev ? { ...prev, constraints: updated.constraints } : null));
+    }
+  };
+
+  const removeMember = async (groupId: string, userId: string): Promise<void> => {
+    if (!currentUser) return;
+    const res = await fetch(apiUrl(`/api/groups/${groupId}/members/${userId}/`), {
+      method: 'DELETE',
+      credentials: 'include',
+      headers: { 'X-CSRFToken': getCsrf() },
+    });
+    if (!res.ok) {
+      const err = await res.json().catch(() => ({}));
+      throw new Error(err.error || 'Failed to remove member');
+    }
     setGroups((prev) =>
       prev.map((g) =>
-        g.id === String(updatedBg.id) ? { ...g, constraints: updatedBg.constraints } : g
+        g.id === groupId ? { ...g, members: g.members.filter((m) => m.userId !== userId) } : g
       )
     );
-    if (currentGroup?.id === String(updatedBg.id)) {
-      setCurrentGroup((prev) =>
-        prev ? { ...prev, constraints: updatedBg.constraints } : null
-      );
-    }
   };
 
   const makeLeader = async (groupId: string, userId: string): Promise<void> => {
     if (!currentUser) return;
-    try {
-      const csrftoken = getCookie('csrftoken') || '';
-      const response = await fetch(
-        apiUrl(`/api/groups/${groupId}/members/${userId}/role/`),
-        {
-          method: 'PATCH',
-          credentials: 'include',
-          headers: {
-            'X-CSRFToken': csrftoken,
-          },
-        }
-      );
+    const res = await fetch(apiUrl(`/api/groups/${groupId}/members/${userId}/role/`), {
+      method: 'PATCH',
+      credentials: 'include',
+      headers: { 'X-CSRFToken': getCsrf() },
+    });
+    if (!res.ok) {
+      const err = await res.json().catch(() => ({}));
+      throw new Error(err.error || 'Failed to promote member');
+    }
+    setGroups((prev) =>
+      prev.map((g) =>
+        g.id === groupId
+          ? { ...g, members: g.members.map((m) => (m.userId === userId ? { ...m, isLeader: true } : m)) }
+          : g
+      )
+    );
+  };
 
-      if (!response.ok) {
-        const err = await response.json().catch(() => ({}));
-        throw new Error(err.error || 'Failed to promote member');
-      }
-
-      setGroups((prevGroups) =>
-        prevGroups.map((group) => {
-          if (group.id === groupId) {
-            return {
-              ...group,
-              members: group.members.map((m) =>
-                m.userId === userId ? { ...m, isLeader: true } : m
-              ),
-            };
-          }
-          return group;
-        })
-      );
-    } catch (error) {
-      console.error('Make leader error:', error);
-      throw error;
+  const inviteMember = async (groupId: string, userEmail: string): Promise<void> => {
+    if (!currentUser) return;
+    const res = await fetch(apiUrl(`/api/groups/${groupId}/invite/`), {
+      method: 'POST',
+      credentials: 'include',
+      headers: { 'Content-Type': 'application/json', 'X-CSRFToken': getCsrf() },
+      body: JSON.stringify({ email: userEmail }),
+    });
+    if (!res.ok) {
+      const err = await res.json().catch(() => ({}));
+      throw new Error(err.error || 'Failed to invite user');
     }
   };
 
   const fetchAvailableUsers = useCallback(
     async (query: string = '', groupId?: string) => {
       if (!currentUser) return;
+      let url = `/api/groups/users/?q=${encodeURIComponent(query)}`;
+      if (groupId) url += `&group_id=${encodeURIComponent(groupId)}`;
       try {
-        let url = `/api/groups/users/?q=${encodeURIComponent(query)}`;
-        if (groupId) {
-          url += `&group_id=${encodeURIComponent(groupId)}`;
-        }
-        const response = await fetch(apiUrl(url), {
-          credentials: 'include',
-        });
-        if (response.ok) {
-          const data = await response.json();
-          const users = data.users.map((u: BackendUser & { is_invited?: boolean }) => ({
-            id: String(u.id),
-            email: u.email,
-            name: u.name,
-            preferences: { cuisines: [], dietary: [], foodTypes: [] }, // Minimal mock for interface
-            is_invited: u.is_invited,
-          }));
-          setAvailableUsers(users);
+        const res = await fetch(apiUrl(url), { credentials: 'include' });
+        if (res.ok) {
+          const data = await res.json();
+          setAvailableUsers(
+            data.users.map((u: BackendUser & { is_invited?: boolean }) => ({
+              id: String(u.id),
+              email: u.email,
+              name: u.name,
+              preferences: { cuisines: [], dietary: [], foodTypes: [] },
+              is_invited: u.is_invited,
+            }))
+          );
         }
       } catch (error) {
         console.error('Failed to fetch users:', error);
@@ -1070,9 +600,11 @@ export function AppProvider({ children }: { children: ReactNode }) {
     [currentUser]
   );
 
-  const getAllUsers = () => {
-    return availableUsers;
-  };
+  const getAllUsers = () => availableUsers;
+
+  // ---------------------------------------------------------------------------
+  // Swipe events
+  // ---------------------------------------------------------------------------
 
   const createSwipeEvent = async (
     groupId: string,
@@ -1080,81 +612,61 @@ export function AppProvider({ children }: { children: ReactNode }) {
     borough?: string,
     neighborhood?: string
   ): Promise<SwipeEvent> => {
-    const csrftoken = getCookie('csrftoken') || '';
-    const response = await fetch(apiUrl(`/api/groups/${groupId}/events/`), {
+    const res = await fetch(apiUrl(`/api/groups/${groupId}/events/`), {
       method: 'POST',
       credentials: 'include',
-      headers: {
-        'Content-Type': 'application/json',
-        'X-CSRFToken': csrftoken,
-      },
+      headers: { 'Content-Type': 'application/json', 'X-CSRFToken': getCsrf() },
       body: JSON.stringify({ name, borough, neighborhood }),
     });
-    const data = await response.json();
-    if (!response.ok) throw new Error(data.error || 'Failed to create event');
-
+    const data = await res.json();
+    if (!res.ok) throw new Error(data.error || 'Failed to create event');
     const newEvent: SwipeEvent = {
       id: String(data.event.id),
       groupId: String(data.event.group_id),
       name: data.event.name,
       status: data.event.status,
       createdAt: data.event.created_at,
-      matchedRestaurantId: data.event.matched_venue_id
-        ? String(data.event.matched_venue_id)
-        : undefined,
+      matchedRestaurantId: data.event.matched_venue_id ? String(data.event.matched_venue_id) : undefined,
       borough: data.event.borough || '',
       neighborhood: data.event.neighborhood || '',
     };
-
     setSwipeEvents((prev) => [...prev, newEvent]);
-
     addChatMessage(groupId, {
       id: `msg-${Date.now()}`,
       type: 'system',
       message: `New swipe session started: ${name}`,
       timestamp: new Date().toISOString(),
     });
-
     return newEvent;
   };
 
-  const fetchSwipeEvents = useCallback(
-    async (groupId: string, signal?: AbortSignal) => {
-      try {
-        const response = await fetch(apiUrl(`/api/groups/${groupId}/events/`), {
-          credentials: 'include',
-          signal,
-        });
-        const data = await response.json();
-        if (data.success) {
-          const events: SwipeEvent[] = data.events.map(
-            (e: {
-              id: number;
-              group_id: number;
-              name: string;
-              status: string;
-              created_at: string;
-              matched_venue_id: number | null;
-            }) => ({
-              id: String(e.id),
-              groupId: String(e.group_id),
-              name: e.name,
-              status: e.status as SwipeEvent['status'],
-              createdAt: e.created_at,
-              matchedRestaurantId: e.matched_venue_id
-                ? String(e.matched_venue_id)
-                : undefined,
-            })
-          );
-          setSwipeEvents(events);
-        }
-      } catch (error) {
-        if (error instanceof DOMException && error.name === 'AbortError') return;
-        console.error('Failed to fetch swipe events:', error);
+  const fetchSwipeEvents = useCallback(async (groupId: string, signal?: AbortSignal) => {
+    try {
+      const res = await fetch(apiUrl(`/api/groups/${groupId}/events/`), {
+        credentials: 'include',
+        signal,
+      });
+      const data = await res.json();
+      if (data.success) {
+        setSwipeEvents(
+          data.events.map((e: {
+            id: number; group_id: number; name: string; status: string;
+            created_at: string; matched_venue_id: number | null;
+          }) => ({
+            id: String(e.id),
+            groupId: String(e.group_id),
+            name: e.name,
+            status: e.status as SwipeEvent['status'],
+            createdAt: e.created_at,
+            matchedRestaurantId: e.matched_venue_id ? String(e.matched_venue_id) : undefined,
+          }))
+        );
       }
-    },
-    []
-  );
+    } catch (error) {
+      if (error instanceof DOMException && error.name === 'AbortError') return;
+      console.error('Failed to fetch swipe events:', error);
+    }
+  }, []);
 
   const addSwipe = async (
     eventId: string,
@@ -1162,44 +674,32 @@ export function AppProvider({ children }: { children: ReactNode }) {
     venueId: string,
     direction: 'left' | 'right'
   ) => {
-    const csrftoken = getCookie('csrftoken') || '';
-    const response = await fetch(
-      apiUrl(`/api/groups/${groupId}/events/${eventId}/swipes/`),
-      {
-        method: 'POST',
-        credentials: 'include',
-        headers: {
-          'Content-Type': 'application/json',
-          'X-CSRFToken': csrftoken,
-        },
-        body: JSON.stringify({ venue_id: Number(venueId), direction }),
-      }
-    );
-    if (!response.ok) {
-      const data = await response.json();
+    const res = await fetch(apiUrl(`/api/groups/${groupId}/events/${eventId}/swipes/`), {
+      method: 'POST',
+      credentials: 'include',
+      headers: { 'Content-Type': 'application/json', 'X-CSRFToken': getCsrf() },
+      body: JSON.stringify({ venue_id: Number(venueId), direction }),
+    });
+    if (!res.ok) {
+      const data = await res.json();
       throw new Error(data.error || 'Failed to submit swipe');
     }
   };
 
-  const fetchSwipeVenues = useCallback(
-    async (groupId: string, eventId: string): Promise<Restaurant[]> => {
-      const response = await fetch(
-        apiUrl(`/api/groups/${groupId}/events/${eventId}/venues/`),
-        { credentials: 'include' }
-      );
-      const data = await response.json();
-      if (!data.success) throw new Error('Failed to fetch venues');
-      return data.venues as Restaurant[];
-    },
-    []
-  );
+  const fetchSwipeVenues = useCallback(async (groupId: string, eventId: string): Promise<Restaurant[]> => {
+    const res = await fetch(apiUrl(`/api/groups/${groupId}/events/${eventId}/venues/`), {
+      credentials: 'include',
+    });
+    const data = await res.json();
+    if (!data.success) throw new Error('Failed to fetch venues');
+    return data.venues as Restaurant[];
+  }, []);
 
   const fetchMatchResults = useCallback(async (groupId: string, eventId: string) => {
-    const response = await fetch(
-      apiUrl(`/api/groups/${groupId}/events/${eventId}/results/`),
-      { credentials: 'include' }
-    );
-    const data = await response.json();
+    const res = await fetch(apiUrl(`/api/groups/${groupId}/events/${eventId}/results/`), {
+      credentials: 'include',
+    });
+    const data = await res.json();
     if (!data.success) throw new Error('Failed to fetch results');
     return {
       match_found: data.match_found as boolean,
@@ -1210,71 +710,47 @@ export function AppProvider({ children }: { children: ReactNode }) {
     };
   }, []);
 
+  const updateSwipeEventStatus = (eventId: string, status: SwipeEvent['status'], matchedId?: string) => {
+    setSwipeEvents((events) =>
+      events.map((e) => (e.id === eventId ? { ...e, status, matchedRestaurantId: matchedId } : e))
+    );
+  };
+
+  // ---------------------------------------------------------------------------
+  // Chat / DMs
+  // ---------------------------------------------------------------------------
+
   const addChatMessage = async (conversationId: string, message: ChatMessage) => {
-    try {
-      const csrftoken = getCookie('csrftoken') || '';
-      const response = await fetch(apiUrl(`/api/chat/${conversationId}/messages/`), {
-        method: 'POST',
-        credentials: 'include',
-        headers: {
-          'Content-Type': 'application/json',
-          'X-CSRFToken': csrftoken,
-        },
-        body: JSON.stringify({ message: message.message, message_type: message.type }),
-      });
-
-      if (!response.ok) {
-        let errorDetail: unknown = null;
-        try {
-          const contentType = response.headers.get('Content-Type') || '';
-          if (contentType.includes('application/json')) {
-            errorDetail = await response.json();
-          } else {
-            errorDetail = await response.text();
-          }
-        } catch {
-          // Ignore secondary errors while parsing error response
-        }
-
-        console.error('Failed to send message', {
-          status: response.status,
-          statusText: response.statusText,
-          detail: errorDetail,
-        });
-
-        const errorMessage =
-          typeof errorDetail === 'string' ? errorDetail : 'Failed to send message';
-        throw new Error(errorMessage);
-      }
-
-      const data = await response.json();
-      setChatMessages((prev) => ({
-        ...prev,
-        [conversationId]: [...(prev[conversationId] || []), data.message],
-      }));
-
-      return data.message;
-    } catch (err) {
-      console.error('Failed to send message', err);
-      throw err;
+    const res = await fetch(apiUrl(`/api/chat/${conversationId}/messages/`), {
+      method: 'POST',
+      credentials: 'include',
+      headers: { 'Content-Type': 'application/json', 'X-CSRFToken': getCsrf() },
+      body: JSON.stringify({ message: message.message, message_type: message.type }),
+    });
+    if (!res.ok) {
+      let detail: unknown = null;
+      try {
+        const ct = res.headers.get('Content-Type') || '';
+        detail = ct.includes('application/json') ? await res.json() : await res.text();
+      } catch { /* ignore */ }
+      throw new Error(typeof detail === 'string' ? detail : 'Failed to send message');
     }
+    const data = await res.json();
+    setChatMessages((prev) => ({
+      ...prev,
+      [conversationId]: [...(prev[conversationId] || []), data.message],
+    }));
+    return data.message;
   };
 
   const deleteChatMessage = async (conversationId: string, messageId: string) => {
     try {
-      const csrftoken = getCookie('csrftoken') || '';
-      const response = await fetch(
-        apiUrl(`/api/chat/${conversationId}/messages/${messageId}/`),
-        {
-          method: 'DELETE',
-          credentials: 'include',
-          headers: {
-            'X-CSRFToken': csrftoken,
-          },
-        }
-      );
-
-      if (response.ok) {
+      const res = await fetch(apiUrl(`/api/chat/${conversationId}/messages/${messageId}/`), {
+        method: 'DELETE',
+        credentials: 'include',
+        headers: { 'X-CSRFToken': getCsrf() },
+      });
+      if (res.ok) {
         setChatMessages((prev) => {
           const messages = prev[conversationId] || [];
           return {
@@ -1292,105 +768,58 @@ export function AppProvider({ children }: { children: ReactNode }) {
     }
   };
 
-  const createDMConversation = async (
-    participantId: string
-  ): Promise<DMConversation> => {
+  const createDMConversation = async (participantId: string): Promise<DMConversation> => {
     if (!currentUser) throw new Error('Must be logged in');
-
-    try {
-      const csrftoken = getCookie('csrftoken') || '';
-      const response = await fetch(apiUrl(`/api/chat/`), {
-        method: 'POST',
-        credentials: 'include',
-        headers: {
-          'Content-Type': 'application/json',
-          'X-CSRFToken': csrftoken,
-        },
-        body: JSON.stringify({ participantId }),
-      });
-
-      if (response.ok) {
-        const data = await response.json();
-        const chat = data.chat;
-        const newDm: DMConversation = {
-          id: chat.id,
-          participants: chat.participants,
-          participantNames: chat.participantNames,
-          // Normalize lastMessageTime: backend may return null when there are no messages
-          lastMessageTime: chat.lastMessageTime || chat.created_at,
-        };
-        setDMConversations((prev) => [
-          ...prev.filter((dm) => dm.id !== chat.id),
-          newDm,
-        ]);
-        setChatMessages((prev) => ({
-          ...prev,
-          [`dm-${chat.id}`]: chat.messages || [],
-        }));
-        return newDm;
-      }
-    } catch (err) {
-      console.error('Failed to create DM', err);
+    const res = await fetch(apiUrl('/api/chat/'), {
+      method: 'POST',
+      credentials: 'include',
+      headers: { 'Content-Type': 'application/json', 'X-CSRFToken': getCsrf() },
+      body: JSON.stringify({ participantId }),
+    });
+    if (res.ok) {
+      const data = await res.json();
+      const chat = data.chat;
+      const newDm: DMConversation = {
+        id: chat.id,
+        participants: chat.participants,
+        participantNames: chat.participantNames,
+        lastMessageTime: chat.lastMessageTime || chat.created_at,
+      };
+      setDMConversations((prev) => [...prev.filter((dm) => dm.id !== chat.id), newDm]);
+      setChatMessages((prev) => ({ ...prev, [`dm-${chat.id}`]: chat.messages || [] }));
+      return newDm;
     }
     throw new Error('Failed to create DM');
   };
 
-  const toggleMuteChatMember = async (
-    chatId: string,
-    userId: string
-  ): Promise<void> => {
-    try {
-      const csrftoken = getCookie('csrftoken') || '';
-      const response = await fetch(
-        apiUrl(`/api/chat/${chatId}/members/${userId}/mute/`),
-        {
-          method: 'POST',
-          headers: { 'X-CSRFToken': csrftoken },
-          credentials: 'include',
-        }
-      );
-      if (!response.ok) throw new Error('Failed to toggle mute');
-      await fetchUserChats();
-    } catch (err) {
-      console.error(err);
-      throw err;
-    }
+  const toggleMuteChatMember = async (chatId: string, userId: string): Promise<void> => {
+    const res = await fetch(apiUrl(`/api/chat/${chatId}/members/${userId}/mute/`), {
+      method: 'POST',
+      headers: { 'X-CSRFToken': getCsrf() },
+      credentials: 'include',
+    });
+    if (!res.ok) throw new Error('Failed to toggle mute');
+    await fetchUserChats();
   };
 
   const openUserDM = async (userId: string): Promise<void> => {
     window.dispatchEvent(new CustomEvent('open-chat-dm', { detail: userId }));
   };
 
-  const updateSwipeEventStatus = (
-    eventId: string,
-    status: SwipeEvent['status'],
-    matchedId?: string
-  ) => {
-    setSwipeEvents((events) =>
-      events.map((event) =>
-        event.id === eventId
-          ? { ...event, status, matchedRestaurantId: matchedId }
-          : event
-      )
-    );
-  };
+  // ---------------------------------------------------------------------------
+  // Render — block until auth is resolved
+  // ---------------------------------------------------------------------------
 
-  // Skip rendering the rest of the application until we've checked the auth state
-  if (isInitializingAuth) {
-    return null; // Or a loading spinner
+  if (auth.isInitializingAuth) {
+    return null;
   }
 
   return (
     <AppContext.Provider
       value={{
-        currentUser,
-        login,
-        register,
-        logout,
-        requestPasswordReset,
-        validatePasswordResetToken,
-        confirmPasswordReset,
-        updatePreferences,
+        // Auth (from AuthProvider)
+        ...auth,
+        // Groups
         groups,
         createGroup,
         joinGroup,
@@ -1407,6 +836,7 @@ export function AppProvider({ children }: { children: ReactNode }) {
         availableUsers,
         currentGroup,
         setCurrentGroup,
+        // Swipe events
         swipeEvents,
         createSwipeEvent,
         fetchSwipeEvents,
@@ -1416,6 +846,8 @@ export function AppProvider({ children }: { children: ReactNode }) {
         addSwipe,
         fetchSwipeVenues,
         fetchMatchResults,
+        updateSwipeEventStatus,
+        // Chat / DMs
         chatMessages,
         addChatMessage,
         deleteChatMessage,
@@ -1424,7 +856,7 @@ export function AppProvider({ children }: { children: ReactNode }) {
         openUserDM,
         dmConversations,
         createDMConversation,
-        updateSwipeEventStatus,
+        // Invitations / notifications
         invitations,
         swipeNotifications,
         fetchInvitations,
@@ -1438,8 +870,20 @@ export function AppProvider({ children }: { children: ReactNode }) {
   );
 }
 
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+export function AppProvider({ children }: { children: ReactNode }) {
+  return (
+    <AuthProvider>
+      <AppInner>{children}</AppInner>
+    </AuthProvider>
+  );
+}
+
 // eslint-disable-next-line react-refresh/only-export-components
-export function useApp() {
+export function useApp(): AppContextType {
   const context = useContext(AppContext);
   if (context === undefined) {
     throw new Error('useApp must be used within an AppProvider');

--- a/frontend/src/app/contexts/app-context.tsx
+++ b/frontend/src/app/contexts/app-context.tsx
@@ -481,7 +481,7 @@ function AppInner({ children }: { children: ReactNode }) {
 
   const deleteGroup = async (groupId: string): Promise<void> => {
     if (!currentUser) return;
-    const res = await fetch(apiUrl(`/api/groups/${groupId}/`), {
+    const res = await fetch(apiUrl(`/api/groups/${groupId}/delete/`), {
       method: 'DELETE',
       credentials: 'include',
       headers: { 'X-CSRFToken': getCsrf() },

--- a/frontend/src/app/contexts/app-context.tsx
+++ b/frontend/src/app/contexts/app-context.tsx
@@ -196,7 +196,7 @@ function AppInner({ children }: { children: ReactNode }) {
   const [currentGroup, setCurrentGroup] = useState<Group | null>(null);
   const [swipeEvents, setSwipeEvents] = useState<SwipeEvent[]>([]);
   const [currentSwipeEvent, setCurrentSwipeEvent] = useState<SwipeEvent | null>(null);
-  const [swipes] = useState<Record<string, Swipe[]>>({});
+  const swipes: Record<string, Swipe[]> = {};
   const [chatMessages, setChatMessages] = useState<Record<string, ChatMessage[]>>({});
   const [dmConversations, setDMConversations] = useState<DMConversation[]>([]);
   const [chatMutedParticipants, setChatMutedParticipants] = useState<Record<string, string[]>>({});

--- a/frontend/src/app/contexts/app-context.tsx
+++ b/frontend/src/app/contexts/app-context.tsx
@@ -297,7 +297,7 @@ export function AppProvider({ children }: { children: ReactNode }) {
   const [currentGroup, setCurrentGroup] = useState<Group | null>(null);
   const [swipeEvents, setSwipeEvents] = useState<SwipeEvent[]>([]);
   const [currentSwipeEvent, setCurrentSwipeEvent] = useState<SwipeEvent | null>(null);
-  const [swipes, setSwipes] = useState<Record<string, Swipe[]>>({});
+  const [swipes] = useState<Record<string, Swipe[]>>({});
   const [chatMessages, setChatMessages] = useState<Record<string, ChatMessage[]>>({});
   const [dmConversations, setDMConversations] = useState<DMConversation[]>([]);
   const [chatMutedParticipants, setChatMutedParticipants] = useState<
@@ -306,282 +306,24 @@ export function AppProvider({ children }: { children: ReactNode }) {
   const [invitations, setInvitations] = useState<Invitation[]>([]);
   const [swipeNotifications, setSwipeNotifications] = useState<SwipeNotification[]>([]);
 
-  // Seed initial data if not exists
+  // Clean up legacy localStorage demo data left from older versions of the app.
+  // This runs once on mount — it does not seed anything new.
   useEffect(() => {
-    const hasSeeded = localStorage.getItem('mealswipe_seeded');
-    const currentVersion = localStorage.getItem('mealswipe_version');
-    const CURRENT_VERSION = '3'; // Increment when schema changes
-
-    // Reset data if version changed (for schema updates like isLeader field)
-    if (currentVersion !== CURRENT_VERSION) {
-      localStorage.removeItem('mealswipe_groups');
-      localStorage.removeItem('mealswipe_events');
-      localStorage.removeItem('mealswipe_swipes');
-      localStorage.removeItem('mealswipe_messages');
-      localStorage.removeItem('mealswipe_notifications');
-      localStorage.removeItem('mealswipe_seeded');
-    }
-
-    if (!hasSeeded || currentVersion !== CURRENT_VERSION) {
-      // Create a pre-existing group for Feb 7, 2026
-      const feb7Group: Group = {
-        id: 'group-feb7-2026',
-        name: 'Friday Night Dinner Club',
-        members: [
-          {
-            userId: '1',
-            userName: 'Alex Chen',
-            hasFinishedSwiping: false,
-            isLeader: true,
-          },
-          {
-            userId: '2',
-            userName: 'Sarah Kim',
-            hasFinishedSwiping: false,
-            isLeader: false,
-          },
-          {
-            userId: '3',
-            userName: 'Jordan Lee',
-            hasFinishedSwiping: false,
-            isLeader: false,
-          },
-          {
-            userId: '4',
-            userName: 'Emma Rodriguez',
-            hasFinishedSwiping: false,
-            isLeader: false,
-          },
-        ],
-        createdBy: '1',
-        createdAt: '2026-02-01T10:00:00.000Z',
-      };
-
-      // Create a swipe event for Feb 7
-      const feb7Event: SwipeEvent = {
-        id: 'event-feb7-2026',
-        groupId: 'group-feb7-2026',
-        name: 'Friday Dinner - Feb 7',
-        status: 'pending',
-        createdAt: '2026-02-01T10:00:00.000Z',
-      };
-
-      // Add initial chat messages
-      const initialMessages: Record<string, ChatMessage[]> = {
-        'group-feb7-2026': [
-          {
-            id: 'msg-1',
-            type: 'system',
-            message: 'Alex Chen created the group',
-            timestamp: '2026-02-01T10:00:00.000Z',
-          },
-          {
-            id: 'msg-2',
-            type: 'system',
-            message: 'Sarah Kim joined the group',
-            timestamp: '2026-02-01T10:15:00.000Z',
-          },
-          {
-            id: 'msg-3',
-            type: 'system',
-            message: 'Jordan Lee joined the group',
-            timestamp: '2026-02-01T11:30:00.000Z',
-          },
-          {
-            id: 'msg-4',
-            type: 'system',
-            message: 'Emma Rodriguez joined the group',
-            timestamp: '2026-02-01T14:20:00.000Z',
-          },
-          {
-            id: 'msg-5',
-            type: 'user',
-            userId: '1',
-            userName: 'Alex Chen',
-            message: 'Hey everyone! Looking forward to dinner on Friday!',
-            timestamp: '2026-02-02T18:00:00.000Z',
-          },
-          {
-            id: 'msg-6',
-            type: 'user',
-            userId: '2',
-            userName: 'Sarah Kim',
-            message: 'Me too! Any preferences on cuisine?',
-            timestamp: '2026-02-02T18:15:00.000Z',
-          },
-          {
-            id: 'msg-7',
-            type: 'user',
-            userId: '3',
-            userName: 'Jordan Lee',
-            message: "I'm down for anything! Maybe Italian or Thai?",
-            timestamp: '2026-02-03T09:30:00.000Z',
-          },
-          {
-            id: 'msg-8',
-            type: 'user',
-            userId: '4',
-            userName: 'Emma Rodriguez',
-            message: 'Thai sounds great! 🍜',
-            timestamp: '2026-02-03T10:15:00.000Z',
-          },
-          {
-            id: 'msg-9',
-            type: 'user',
-            userId: '1',
-            userName: 'Alex Chen',
-            message: "Perfect! Let's start swiping soon so we can make a reservation",
-            timestamp: '2026-02-04T14:20:00.000Z',
-          },
-          {
-            id: 'msg-10',
-            type: 'user',
-            userId: '2',
-            userName: 'Sarah Kim',
-            message: 'Should we aim for 7pm or 8pm?',
-            timestamp: '2026-02-05T16:45:00.000Z',
-          },
-          {
-            id: 'msg-11',
-            type: 'user',
-            userId: '3',
-            userName: 'Jordan Lee',
-            message: '8pm works better for me, I have class until 6:30',
-            timestamp: '2026-02-05T17:00:00.000Z',
-          },
-          {
-            id: 'msg-12',
-            type: 'user',
-            userId: '4',
-            userName: 'Emma Rodriguez',
-            message: '8pm is perfect!',
-            timestamp: '2026-02-05T17:10:00.000Z',
-          },
-        ],
-        // DM with Jordan Lee
-        'dm-jordan-init': [
-          {
-            id: 'dm-msg-1',
-            type: 'user',
-            userId: '3',
-            userName: 'Jordan Lee',
-            message:
-              'Hey! Are you free this Saturday too? Thinking of checking out that new ramen place',
-            timestamp: '2026-02-06T11:30:00.000Z',
-          },
-          {
-            id: 'dm-msg-2',
-            type: 'user',
-            userId: '1',
-            userName: 'Alex Chen',
-            message:
-              "Oh that sounds great! I've been wanting to try that place. What time?",
-            timestamp: '2026-02-06T11:45:00.000Z',
-          },
-          {
-            id: 'dm-msg-3',
-            type: 'user',
-            userId: '3',
-            userName: 'Jordan Lee',
-            message: 'Maybe 1pm? We could walk there from campus',
-            timestamp: '2026-02-06T12:00:00.000Z',
-          },
-        ],
-        // DM with Sarah Kim
-        'dm-sarah-init': [
-          {
-            id: 'dm-msg-4',
-            type: 'user',
-            userId: '2',
-            userName: 'Sarah Kim',
-            message:
-              "Hey! Quick question - do you have the notes from yesterday's lecture?",
-            timestamp: '2026-02-07T09:15:00.000Z',
-          },
-          {
-            id: 'dm-msg-5',
-            type: 'user',
-            userId: '1',
-            userName: 'Alex Chen',
-            message: "Yeah I do! I'll send them over in a bit",
-            timestamp: '2026-02-07T09:20:00.000Z',
-          },
-          {
-            id: 'dm-msg-6',
-            type: 'user',
-            userId: '2',
-            userName: 'Sarah Kim',
-            message: 'Thanks! Also super excited for dinner tonight!',
-            timestamp: '2026-02-07T09:25:00.000Z',
-          },
-        ],
-      };
-
-      // Add initial DM conversations
-      const initialDMConversations: DMConversation[] = [
-        {
-          id: 'dm-jordan-init',
-          participants: ['1', '3'], // Alex and Jordan
-          participantNames: ['Alex Chen', 'Jordan Lee'],
-          lastMessageTime: '2026-02-06T12:00:00.000Z',
-        },
-        {
-          id: 'dm-sarah-init',
-          participants: ['1', '2'], // Alex and Sarah
-          participantNames: ['Alex Chen', 'Sarah Kim'],
-          lastMessageTime: '2026-02-07T09:25:00.000Z',
-        },
-      ];
-
-      localStorage.setItem('mealswipe_groups', JSON.stringify([feb7Group]));
-      localStorage.setItem('mealswipe_events', JSON.stringify([feb7Event]));
-      localStorage.setItem('mealswipe_messages', JSON.stringify(initialMessages));
-      localStorage.setItem(
-        'mealswipe_dm_conversations',
-        JSON.stringify(initialDMConversations)
-      );
-      localStorage.setItem('mealswipe_seeded', 'true');
-      localStorage.setItem('mealswipe_version', CURRENT_VERSION);
-
-      setGroups([feb7Group]);
-      setSwipeEvents([feb7Event]);
-      setChatMessages(initialMessages);
-      setDMConversations(initialDMConversations);
-    }
+    const LEGACY_KEYS = [
+      'mealswipe_seeded',
+      'mealswipe_version',
+      'mealswipe_groups',
+      'mealswipe_events',
+      'mealswipe_swipes',
+      'mealswipe_messages',
+      'mealswipe_notifications',
+      'mealswipe_dm_conversations',
+      'mealswipe_user',
+    ];
+    LEGACY_KEYS.forEach((k) => localStorage.removeItem(k));
   }, []);
 
-  // Load from localStorage on mount
-  useEffect(() => {
-    const storedUser = localStorage.getItem('mealswipe_user');
-    if (storedUser) {
-      setCurrentUser(JSON.parse(storedUser));
-    }
 
-    const storedGroups = localStorage.getItem('mealswipe_groups');
-    if (storedGroups) {
-      setGroups(JSON.parse(storedGroups));
-    }
-
-    const storedEvents = localStorage.getItem('mealswipe_events');
-    if (storedEvents) {
-      setSwipeEvents(JSON.parse(storedEvents));
-    }
-
-    const storedSwipes = localStorage.getItem('mealswipe_swipes');
-    if (storedSwipes) {
-      setSwipes(JSON.parse(storedSwipes));
-    }
-
-    const storedMessages = localStorage.getItem('mealswipe_messages');
-    if (storedMessages) {
-      setChatMessages(JSON.parse(storedMessages));
-    }
-
-    const storedDMConversations = localStorage.getItem('mealswipe_dm_conversations');
-    if (storedDMConversations) {
-      setDMConversations(JSON.parse(storedDMConversations));
-    }
-  }, []);
 
   // ---------------------------------------------------------------------------
   // ACTUAL API AUTHENTICATION LOGIC (Django Session Auth)
@@ -941,35 +683,17 @@ export function AppProvider({ children }: { children: ReactNode }) {
       setCurrentUser(null);
       setCurrentGroup(null);
       setCurrentSwipeEvent(null);
-      localStorage.removeItem('mealswipe_user'); // Still clean up local storage just in case
+      setGroups([]);
+      setSwipeEvents([]);
+      setChatMessages({});
+      setDMConversations([]);
+      setInvitations([]);
+      setSwipeNotifications([]);
     } catch (error) {
       console.error('Logout error:', error);
     }
   };
 
-  // ---------------------------------------------------------------------------
-  // APP / UI STATE SAVING LOGIC
-  // ---------------------------------------------------------------------------
-
-  useEffect(() => {
-    localStorage.setItem('mealswipe_groups', JSON.stringify(groups));
-  }, [groups]);
-
-  useEffect(() => {
-    localStorage.setItem('mealswipe_events', JSON.stringify(swipeEvents));
-  }, [swipeEvents]);
-
-  useEffect(() => {
-    localStorage.setItem('mealswipe_swipes', JSON.stringify(swipes));
-  }, [swipes]);
-
-  useEffect(() => {
-    localStorage.setItem('mealswipe_messages', JSON.stringify(chatMessages));
-  }, [chatMessages]);
-
-  useEffect(() => {
-    localStorage.setItem('mealswipe_dm_conversations', JSON.stringify(dmConversations));
-  }, [dmConversations]);
 
   const createGroup = async (
     name: string,

--- a/frontend/src/app/contexts/app-context.tsx
+++ b/frontend/src/app/contexts/app-context.tsx
@@ -681,8 +681,8 @@ function AppInner({ children }: { children: ReactNode }) {
       body: JSON.stringify({ venue_id: Number(venueId), direction }),
     });
     if (!res.ok) {
-      const data = await res.json();
-      throw new Error(data.error || 'Failed to submit swipe');
+      const data = await res.json().catch(() => ({}));
+      throw new Error(data.error || `Failed to submit swipe (${res.status})`);
     }
   };
 

--- a/frontend/src/app/contexts/app-context.tsx
+++ b/frontend/src/app/contexts/app-context.tsx
@@ -154,7 +154,6 @@ export interface AppContextType extends AuthContextType {
   fetchSwipeEvents: (groupId: string, signal?: AbortSignal) => Promise<void>;
   currentSwipeEvent: SwipeEvent | null;
   setCurrentSwipeEvent: (event: SwipeEvent | null) => void;
-  swipes: Record<string, Swipe[]>;
   addSwipe: (eventId: string, groupId: string, venueId: string, direction: 'left' | 'right') => Promise<void>;
   fetchSwipeVenues: (groupId: string, eventId: string) => Promise<Restaurant[]>;
   fetchMatchResults: (groupId: string, eventId: string) => Promise<{
@@ -196,7 +195,7 @@ function AppInner({ children }: { children: ReactNode }) {
   const [currentGroup, setCurrentGroup] = useState<Group | null>(null);
   const [swipeEvents, setSwipeEvents] = useState<SwipeEvent[]>([]);
   const [currentSwipeEvent, setCurrentSwipeEvent] = useState<SwipeEvent | null>(null);
-  const swipes: Record<string, Swipe[]> = {};
+
   const [chatMessages, setChatMessages] = useState<Record<string, ChatMessage[]>>({});
   const [dmConversations, setDMConversations] = useState<DMConversation[]>([]);
   const [chatMutedParticipants, setChatMutedParticipants] = useState<Record<string, string[]>>({});
@@ -842,7 +841,6 @@ function AppInner({ children }: { children: ReactNode }) {
         fetchSwipeEvents,
         currentSwipeEvent,
         setCurrentSwipeEvent,
-        swipes,
         addSwipe,
         fetchSwipeVenues,
         fetchMatchResults,

--- a/frontend/src/app/contexts/auth-context.tsx
+++ b/frontend/src/app/contexts/auth-context.tsx
@@ -132,11 +132,11 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       headers: { 'Content-Type': 'application/json', 'X-CSRFToken': csrftoken },
       body: JSON.stringify({ email, password }),
     });
-    const data = await response.json();
+    const data = await response.json().catch(() => ({}));
     if (response.ok && data.success) {
       setCurrentUser(normalizeApiUser(data.user));
     } else {
-      throw new Error(data.error || 'Login failed');
+      throw new Error(data.error || `Login failed (${response.status})`);
     }
   };
 
@@ -148,11 +148,11 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       headers: { 'Content-Type': 'application/json', 'X-CSRFToken': csrftoken },
       body: JSON.stringify(userData),
     });
-    const data = await response.json();
+    const data = await response.json().catch(() => ({}));
     if (response.ok && data.success) {
       setCurrentUser(normalizeApiUser(data.user));
     } else {
-      let errorMessage = data.error || 'Registration failed';
+      let errorMessage = data.error || `Registration failed (${response.status})`;
       if (data.errors && typeof data.errors === 'object') {
         const firstKey = Object.keys(data.errors)[0];
         if (firstKey && data.errors[firstKey]?.length > 0) {

--- a/frontend/src/app/contexts/auth-context.tsx
+++ b/frontend/src/app/contexts/auth-context.tsx
@@ -1,0 +1,277 @@
+import { createContext, useContext, useState, useEffect } from 'react';
+import type { ReactNode } from 'react';
+import { apiUrl, getCsrf } from '@/app/lib/api';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface User {
+  id: string;
+  name: string;
+  email: string;
+  role?: 'student' | 'venue_manager' | 'admin';
+  preferences: {
+    cuisines: string[];
+    dietary: string[];
+    foodTypes: string[];
+    minimumSanitationGrade?: string;
+  };
+  is_invited?: boolean;
+}
+
+interface RegisterData {
+  first_name: string;
+  last_name: string;
+  email: string;
+  password: string;
+  preferences?: {
+    cuisines?: string[];
+    dietary?: string[];
+    foodTypes?: string[];
+    minimum_sanitation_grade?: string;
+  };
+}
+
+export interface AuthContextType {
+  currentUser: User | null;
+  isInitializingAuth: boolean;
+  login: (email: string, password: string) => Promise<void>;
+  register: (data: RegisterData) => Promise<void>;
+  logout: () => Promise<void>;
+  updatePreferences: (preferences: {
+    dietary?: string[];
+    cuisines?: string[];
+    foodTypes?: string[];
+    minimumSanitationGrade?: string;
+  }) => Promise<void>;
+  requestPasswordReset: (email: string) => Promise<void>;
+  validatePasswordResetToken: (uid: string, token: string) => Promise<void>;
+  confirmPasswordReset: (uid: string, token: string, newPassword: string) => Promise<void>;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const DEFAULT_PREFERENCES = {
+  cuisines: [] as string[],
+  dietary: [] as string[],
+  foodTypes: [] as string[],
+  minimumSanitationGrade: 'A' as string,
+};
+
+// eslint-disable-next-line react-refresh/only-export-components
+export function normalizeApiUser(apiUser: {
+  id: number | string;
+  email: string;
+  name: string;
+  role?: 'student' | 'venue_manager' | 'admin';
+  preferences?: {
+    dietary?: string[];
+    cuisines?: string[];
+    foodTypes?: string[];
+    minimum_sanitation_grade?: string;
+  };
+  is_invited?: boolean;
+}): User {
+  const prefs = apiUser.preferences ?? {};
+  const grade = prefs.minimum_sanitation_grade ?? 'A';
+  return {
+    id: String(apiUser.id),
+    email: apiUser.email,
+    name: apiUser.name,
+    role: apiUser.role,
+    preferences: {
+      cuisines: Array.isArray(prefs.cuisines) ? prefs.cuisines : DEFAULT_PREFERENCES.cuisines,
+      dietary: Array.isArray(prefs.dietary) ? prefs.dietary : DEFAULT_PREFERENCES.dietary,
+      foodTypes: Array.isArray(prefs.foodTypes) ? prefs.foodTypes : DEFAULT_PREFERENCES.foodTypes,
+      minimumSanitationGrade: grade,
+    },
+    is_invited: apiUser.is_invited,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Context
+// ---------------------------------------------------------------------------
+
+const AuthContext = createContext<AuthContextType | undefined>(undefined);
+
+export function AuthProvider({ children }: { children: ReactNode }) {
+  const [currentUser, setCurrentUser] = useState<User | null>(null);
+  const [isInitializingAuth, setIsInitializingAuth] = useState(true);
+
+  // Check existing session on mount
+  useEffect(() => {
+    const checkSession = async () => {
+      try {
+        const response = await fetch(apiUrl('/api/auth/me/'), {
+          credentials: 'include',
+        });
+        if (response.ok) {
+          const data = await response.json();
+          if (data.authenticated && data.user) {
+            setCurrentUser(normalizeApiUser(data.user));
+          }
+        }
+      } catch (error) {
+        console.error('Session check failed:', error);
+      } finally {
+        setIsInitializingAuth(false);
+      }
+    };
+    checkSession();
+  }, []);
+
+  const login = async (email: string, password: string) => {
+    const csrftoken = getCsrf();
+    const response = await fetch(apiUrl('/api/auth/login/'), {
+      method: 'POST',
+      credentials: 'include',
+      headers: { 'Content-Type': 'application/json', 'X-CSRFToken': csrftoken },
+      body: JSON.stringify({ email, password }),
+    });
+    const data = await response.json();
+    if (response.ok && data.success) {
+      setCurrentUser(normalizeApiUser(data.user));
+    } else {
+      throw new Error(data.error || 'Login failed');
+    }
+  };
+
+  const register = async (userData: RegisterData) => {
+    const csrftoken = getCsrf();
+    const response = await fetch(apiUrl('/api/auth/register/'), {
+      method: 'POST',
+      credentials: 'include',
+      headers: { 'Content-Type': 'application/json', 'X-CSRFToken': csrftoken },
+      body: JSON.stringify(userData),
+    });
+    const data = await response.json();
+    if (response.ok && data.success) {
+      setCurrentUser(normalizeApiUser(data.user));
+    } else {
+      let errorMessage = data.error || 'Registration failed';
+      if (data.errors && typeof data.errors === 'object') {
+        const firstKey = Object.keys(data.errors)[0];
+        if (firstKey && data.errors[firstKey]?.length > 0) {
+          errorMessage = data.errors[firstKey][0];
+        }
+      }
+      throw new Error(errorMessage);
+    }
+  };
+
+  const logout = async () => {
+    try {
+      const csrftoken = getCsrf();
+      await fetch(apiUrl('/api/auth/logout/'), {
+        method: 'POST',
+        credentials: 'include',
+        headers: { 'Content-Type': 'application/json', 'X-CSRFToken': csrftoken },
+      });
+    } catch (error) {
+      console.error('Logout error:', error);
+    } finally {
+      setCurrentUser(null);
+    }
+  };
+
+  const updatePreferences = async (preferences: {
+    dietary?: string[];
+    cuisines?: string[];
+    foodTypes?: string[];
+    minimumSanitationGrade?: string;
+  }) => {
+    const csrftoken = getCsrf();
+    const body: Record<string, unknown> = {};
+    if (preferences.dietary !== undefined) body.dietary = preferences.dietary;
+    if (preferences.cuisines !== undefined) body.cuisines = preferences.cuisines;
+    if (preferences.foodTypes !== undefined) body.foodTypes = preferences.foodTypes;
+    if (preferences.minimumSanitationGrade !== undefined) {
+      body.minimum_sanitation_grade = preferences.minimumSanitationGrade;
+    }
+    const response = await fetch(apiUrl('/api/auth/preferences/'), {
+      method: 'PATCH',
+      credentials: 'include',
+      headers: { 'Content-Type': 'application/json', 'X-CSRFToken': csrftoken },
+      body: JSON.stringify(body),
+    });
+    if (!response.ok) {
+      const err = await response.json().catch(() => ({}));
+      throw new Error((err as { error?: string }).error || 'Failed to update preferences');
+    }
+    const data = await response.json();
+    if (data.user) setCurrentUser(normalizeApiUser(data.user));
+  };
+
+  const requestPasswordReset = async (email: string) => {
+    const csrftoken = getCsrf();
+    const response = await fetch(apiUrl('/api/auth/request-password-reset/'), {
+      method: 'POST',
+      credentials: 'include',
+      headers: { 'Content-Type': 'application/json', 'X-CSRFToken': csrftoken },
+      body: JSON.stringify({ email }),
+    });
+    const data = await response.json();
+    if (!response.ok || !data.success) {
+      throw new Error(data.error || 'Request failed');
+    }
+  };
+
+  const validatePasswordResetToken = async (uid: string, token: string) => {
+    const csrftoken = getCsrf();
+    const response = await fetch(apiUrl('/api/auth/validate-password-reset-token/'), {
+      method: 'POST',
+      credentials: 'include',
+      headers: { 'Content-Type': 'application/json', 'X-CSRFToken': csrftoken },
+      body: JSON.stringify({ uid, token }),
+    });
+    const data = await response.json();
+    if (!response.ok || !data.success || !data.valid) {
+      throw new Error(data.error || 'Invalid or expired reset link');
+    }
+  };
+
+  const confirmPasswordReset = async (uid: string, token: string, newPassword: string) => {
+    const csrftoken = getCsrf();
+    const response = await fetch(apiUrl('/api/auth/confirm-password-reset/'), {
+      method: 'POST',
+      credentials: 'include',
+      headers: { 'Content-Type': 'application/json', 'X-CSRFToken': csrftoken },
+      body: JSON.stringify({ uid, token, new_password: newPassword }),
+    });
+    const data = await response.json();
+    if (!response.ok || !data.success) {
+      throw new Error(data.error || 'Failed to reset password');
+    }
+  };
+
+  return (
+    <AuthContext.Provider
+      value={{
+        currentUser,
+        isInitializingAuth,
+        login,
+        register,
+        logout,
+        updatePreferences,
+        requestPasswordReset,
+        validatePasswordResetToken,
+        confirmPasswordReset,
+      }}
+    >
+      {children}
+    </AuthContext.Provider>
+  );
+}
+
+// eslint-disable-next-line react-refresh/only-export-components
+export function useAuth(): AuthContextType {
+  const context = useContext(AuthContext);
+  if (context === undefined) {
+    throw new Error('useAuth must be used within an AuthProvider');
+  }
+  return context;
+}

--- a/frontend/src/app/contexts/venue-context.tsx
+++ b/frontend/src/app/contexts/venue-context.tsx
@@ -6,20 +6,7 @@ import {
   useCallback,
   type ReactNode,
 } from 'react';
-
-const API_BASE_URL = import.meta.env.VITE_API_BASE_URL ?? 'http://127.0.0.1:8000';
-
-function apiUrl(path: string) {
-  const normalizedPath = path.startsWith('/') ? path : `/${path}`;
-  return `${API_BASE_URL}${normalizedPath}`;
-}
-
-function getCookie(name: string): string {
-  const value = `; ${document.cookie}`;
-  const parts = value.split(`; ${name}=`);
-  if (parts.length === 2) return parts.pop()?.split(';').shift() ?? '';
-  return '';
-}
+import { apiUrl, getCsrf } from '@/app/lib/api';
 
 // ── Types ─────────────────────────────────────────────────────────────────────
 
@@ -180,7 +167,7 @@ export function VenueProvider({ children }: { children: ReactNode }) {
   }, []);
 
   const loginVenueManager = async (email: string, password: string) => {
-    const csrftoken = getCookie('csrftoken') || '';
+    const csrftoken = getCsrf();
     const response = await fetch(apiUrl('/api/auth/login/'), {
       method: 'POST',
       credentials: 'include',
@@ -206,7 +193,7 @@ export function VenueProvider({ children }: { children: ReactNode }) {
     businessEmail?: string;
     businessPhone?: string;
   }) => {
-    const csrftoken = getCookie('csrftoken') || '';
+    const csrftoken = getCsrf();
     const response = await fetch(apiUrl('/api/auth/venue-register/'), {
       method: 'POST',
       credentials: 'include',
@@ -221,7 +208,7 @@ export function VenueProvider({ children }: { children: ReactNode }) {
   };
 
   const logoutVenueManager = async () => {
-    const csrftoken = getCookie('csrftoken') || '';
+    const csrftoken = getCsrf();
     await fetch(apiUrl('/api/auth/logout/'), {
       method: 'POST',
       credentials: 'include',
@@ -257,7 +244,7 @@ export function VenueProvider({ children }: { children: ReactNode }) {
   };
 
   const claimVenue = async (venueId: number, note = '') => {
-    const csrftoken = getCookie('csrftoken') || '';
+    const csrftoken = getCsrf();
     const response = await fetch(apiUrl(`/api/venues/${venueId}/claim/`), {
       method: 'POST',
       credentials: 'include',
@@ -285,7 +272,7 @@ export function VenueProvider({ children }: { children: ReactNode }) {
   };
 
   const createDiscount = async (venueId: number, formData: DiscountFormData): Promise<StudentDiscount> => {
-    const csrftoken = getCookie('csrftoken') || '';
+    const csrftoken = getCsrf();
     const response = await fetch(apiUrl(`/api/venues/${venueId}/discounts/`), {
       method: 'POST',
       credentials: 'include',
@@ -302,7 +289,7 @@ export function VenueProvider({ children }: { children: ReactNode }) {
     discountId: number,
     formData: Partial<DiscountFormData>
   ): Promise<StudentDiscount> => {
-    const csrftoken = getCookie('csrftoken') || '';
+    const csrftoken = getCsrf();
     const response = await fetch(apiUrl(`/api/venues/${venueId}/discounts/${discountId}/`), {
       method: 'PATCH',
       credentials: 'include',
@@ -315,7 +302,7 @@ export function VenueProvider({ children }: { children: ReactNode }) {
   };
 
   const deleteDiscount = async (venueId: number, discountId: number) => {
-    const csrftoken = getCookie('csrftoken') || '';
+    const csrftoken = getCsrf();
     const response = await fetch(apiUrl(`/api/venues/${venueId}/discounts/${discountId}/`), {
       method: 'DELETE',
       credentials: 'include',

--- a/frontend/src/app/lib/api.ts
+++ b/frontend/src/app/lib/api.ts
@@ -1,0 +1,19 @@
+/**
+ * Shared API helpers used across all context providers.
+ */
+
+const API_BASE_URL = import.meta.env.VITE_API_BASE_URL ?? 'http://127.0.0.1:8000';
+
+/** Build an absolute URL from a backend path. */
+export function apiUrl(path: string): string {
+  const normalizedPath = path.startsWith('/') ? path : `/${path}`;
+  return `${API_BASE_URL}${normalizedPath}`;
+}
+
+/** Read the Django CSRF token from the csrftoken cookie. */
+export function getCsrf(): string {
+  const value = `; ${document.cookie}`;
+  const parts = value.split('; csrftoken=');
+  if (parts.length === 2) return parts.pop()?.split(';').shift() ?? '';
+  return '';
+}

--- a/frontend/src/app/pages/__tests__/group-detail-page.test.tsx
+++ b/frontend/src/app/pages/__tests__/group-detail-page.test.tsx
@@ -61,7 +61,6 @@ describe('GroupDetailPage Synchronization', () => {
       fetchAvailableUsers: vi.fn(),
       getAllUsers: vi.fn().mockReturnValue([]),
       createSwipeEvent: vi.fn(),
-      swipes: {},
       addChatMessage: vi.fn(),
       deleteChatMessage: vi.fn(),
       availableUsers: []

--- a/frontend/src/app/pages/__tests__/swipe-page.test.tsx
+++ b/frontend/src/app/pages/__tests__/swipe-page.test.tsx
@@ -127,7 +127,6 @@ describe('SwipePage Fixed Behaviors', () => {
       // And then navigated straight to Match page as configured
       expect(mockNavigate).toHaveBeenCalledWith('/match/event1');
     });
-
-    toastSpy.mockRestore();
+    // spy is restored automatically by vi.restoreAllMocks() in afterEach (setup.ts)
   });
 });

--- a/frontend/src/app/pages/__tests__/swipe-page.test.tsx
+++ b/frontend/src/app/pages/__tests__/swipe-page.test.tsx
@@ -1,5 +1,6 @@
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
+import * as sonner from 'sonner';
 import { SwipePage } from '../swipe-page';
 import { BrowserRouter } from 'react-router';
 import type { AppContextType } from '@/app/contexts/app-context';
@@ -106,10 +107,8 @@ describe('SwipePage Fixed Behaviors', () => {
 
     // Provide the error mock simulation
     mockAddSwipe.mockRejectedValueOnce(new Error("This event is no longer active"));
-    
-    // Mock window alert
-    const mockAlert = vi.fn();
-    window.alert = mockAlert;
+
+    const toastSpy = vi.spyOn(sonner.toast, 'info').mockImplementation(() => '');
 
     renderComponent();
 
@@ -117,16 +116,18 @@ describe('SwipePage Fixed Behaviors', () => {
     const discardBtn = await waitFor(() => {
       return screen.getByTestId('swipe-discard-btn');
     }, { timeout: 3000 });
-    
+
     // Fire the left swipe which hits our mock Error
     fireEvent.click(discardBtn!);
 
     await waitFor(() => {
-      // Assert it popped up the interceptor alert 
-      expect(mockAlert).toHaveBeenCalledWith("A match has already been found for this session!");
-      
+      // Assert it showed a toast instead of a blocking alert
+      expect(toastSpy).toHaveBeenCalledWith("A match has already been found for this session!");
+
       // And then navigated straight to Match page as configured
       expect(mockNavigate).toHaveBeenCalledWith('/match/event1');
     });
+
+    toastSpy.mockRestore();
   });
 });

--- a/frontend/src/app/pages/admin-venue-edit-page.tsx
+++ b/frontend/src/app/pages/admin-venue-edit-page.tsx
@@ -114,6 +114,7 @@ export function AdminVenueEditPage() {
   const [dietaryTags, setDietaryTags] = useState<string[]>([]);
   const [foodTypeTags, setFoodTypeTags] = useState<string[]>([]);
   const [showRemoveManagerDialog, setShowRemoveManagerDialog] = useState(false);
+  const [removingManager, setRemovingManager] = useState(false);
 
   useEffect(() => {
     const load = async () => {
@@ -240,6 +241,8 @@ export function AdminVenueEditPage() {
   ]);
 
   const handleRemoveManager = async () => {
+    setShowRemoveManagerDialog(false);
+    setRemovingManager(true);
     try {
       const csrftoken = getCsrf();
       const res = await fetch(apiUrl(`/api/venues/admin/venues/${venueId}/`), {
@@ -260,6 +263,8 @@ export function AdminVenueEditPage() {
     } catch (err) {
       console.error(err);
       toast.error('An error occurred.');
+    } finally {
+      setRemovingManager(false);
     }
   };
 
@@ -671,9 +676,10 @@ export function AdminVenueEditPage() {
             <AlertDialogCancel>Cancel</AlertDialogCancel>
             <AlertDialogAction
               className="bg-red-600 hover:bg-red-700 text-white"
+              disabled={removingManager}
               onClick={handleRemoveManager}
             >
-              Remove Manager
+              {removingManager ? 'Removing…' : 'Remove Manager'}
             </AlertDialogAction>
           </AlertDialogFooter>
         </AlertDialogContent>

--- a/frontend/src/app/pages/admin-venue-edit-page.tsx
+++ b/frontend/src/app/pages/admin-venue-edit-page.tsx
@@ -2,6 +2,16 @@ import { useEffect, useState } from 'react';
 import { useNavigate, useParams } from 'react-router';
 import { toast } from 'sonner';
 import { Button } from '@/app/components/ui/button';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/app/components/ui/alert-dialog';
 import { Input } from '@/app/components/ui/input';
 import { Badge } from '@/app/components/ui/badge';
 import { Label } from '@/app/components/ui/label';
@@ -22,18 +32,11 @@ import {
 } from '@/app/components/ui/select';
 import { Save, UserX } from 'lucide-react';
 import preferenceOptions from '@/app/data/preference-options.json';
+import { apiUrl, getCsrf } from '@/app/lib/api';
 
-const API = import.meta.env.VITE_API_BASE_URL ?? 'http://127.0.0.1:8000';
 const BOROUGHS = ['Manhattan', 'Brooklyn', 'Queens', 'Bronx', 'Staten Island'];
 const PRICE_RANGES = ['$', '$$', '$$$', '$$$$'];
 const SANITATION_GRADES = ['A', 'B', 'C', 'N', 'Z', 'P'];
-
-function getCookie(name: string): string {
-  const value = `; ${document.cookie}`;
-  const parts = value.split(`; ${name}=`);
-  if (parts.length === 2) return parts.pop()?.split(';').shift() ?? '';
-  return '';
-}
 
 interface VenueDetail {
   id: number;
@@ -110,16 +113,17 @@ export function AdminVenueEditPage() {
   const [isActive, setIsActive] = useState(true);
   const [dietaryTags, setDietaryTags] = useState<string[]>([]);
   const [foodTypeTags, setFoodTypeTags] = useState<string[]>([]);
+  const [showRemoveManagerDialog, setShowRemoveManagerDialog] = useState(false);
 
   useEffect(() => {
     const load = async () => {
       setLoading(true);
       try {
         const [venueRes, optionsRes] = await Promise.all([
-          fetch(`${API}/api/venues/admin/venues/${venueId}/`, {
+          fetch(apiUrl(`/api/venues/admin/venues/${venueId}/`), {
             credentials: 'include',
           }),
-          fetch(`${API}/api/venues/admin/options/`, { credentials: 'include' }),
+          fetch(apiUrl('/api/venues/admin/options/'), { credentials: 'include' }),
         ]);
         if (venueRes.ok) {
           const vData = await venueRes.json();
@@ -166,7 +170,7 @@ export function AdminVenueEditPage() {
   const handleSave = async () => {
     setSaving(true);
     try {
-      const csrftoken = getCookie('csrftoken') || '';
+      const csrftoken = getCsrf();
       const body = {
         name,
         streetAddress,
@@ -190,7 +194,7 @@ export function AdminVenueEditPage() {
         dietaryTags,
         foodTypeTags,
       };
-      const res = await fetch(`${API}/api/venues/admin/venues/${venueId}/`, {
+      const res = await fetch(apiUrl(`/api/venues/admin/venues/${venueId}/`), {
         method: 'PATCH',
         credentials: 'include',
         headers: {
@@ -234,6 +238,30 @@ export function AdminVenueEditPage() {
     ...(preferenceOptions.foodTypes as string[]),
     ...foodTypeTags,
   ]);
+
+  const handleRemoveManager = async () => {
+    try {
+      const csrftoken = getCsrf();
+      const res = await fetch(apiUrl(`/api/venues/admin/venues/${venueId}/`), {
+        method: 'PATCH',
+        credentials: 'include',
+        headers: { 'Content-Type': 'application/json', 'X-CSRFToken': csrftoken },
+        body: JSON.stringify({ removeManager: true }),
+      });
+      if (res.ok) {
+        const data = await res.json();
+        setVenue(data.venue);
+        setIsVerified(false);
+        toast.success('Venue manager removed successfully.');
+      } else {
+        const data = await res.json();
+        toast.error(data.error || 'Failed to remove manager.');
+      }
+    } catch (err) {
+      console.error(err);
+      toast.error('An error occurred.');
+    }
+  };
 
   if (loading) {
     return (
@@ -562,41 +590,7 @@ export function AdminVenueEditPage() {
                 <Button
                   variant="outline"
                   className="text-red-700 border-red-200 hover:bg-red-50 w-full"
-                  onClick={async () => {
-                    if (
-                      !window.confirm(
-                        `Remove ${venue.manager?.userName || venue.manager?.userEmail} as venue manager?\n\nThis will revoke their verification and all associated claims will be rejected. The venue will become available for a new manager to claim.`
-                      )
-                    )
-                      return;
-                    try {
-                      const csrftoken = getCookie('csrftoken') || '';
-                      const res = await fetch(
-                        `${API}/api/venues/admin/venues/${venueId}/`,
-                        {
-                          method: 'PATCH',
-                          credentials: 'include',
-                          headers: {
-                            'Content-Type': 'application/json',
-                            'X-CSRFToken': csrftoken,
-                          },
-                          body: JSON.stringify({ removeManager: true }),
-                        }
-                      );
-                      if (res.ok) {
-                        const data = await res.json();
-                        setVenue(data.venue);
-                        setIsVerified(false);
-                        toast.success('Venue manager removed successfully.');
-                      } else {
-                        const data = await res.json();
-                        toast.error(data.error || 'Failed to remove manager.');
-                      }
-                    } catch (err) {
-                      console.error(err);
-                      toast.error('An error occurred.');
-                    }
-                  }}
+                  onClick={() => setShowRemoveManagerDialog(true)}
                 >
                   <UserX className="w-4 h-4 mr-1.5" />
                   Remove Venue Manager
@@ -662,6 +656,28 @@ export function AdminVenueEditPage() {
           Cancel
         </Button>
       </div>
+
+      <AlertDialog open={showRemoveManagerDialog} onOpenChange={setShowRemoveManagerDialog}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Remove venue manager?</AlertDialogTitle>
+            <AlertDialogDescription>
+              Remove {venue.manager?.userName || venue.manager?.userEmail} as venue manager?
+              This will revoke their verification and all associated claims will be rejected.
+              The venue will become available for a new manager to claim.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              className="bg-red-600 hover:bg-red-700 text-white"
+              onClick={handleRemoveManager}
+            >
+              Remove Manager
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </div>
   );
 }

--- a/frontend/src/app/pages/admin-venue-verification-page.tsx
+++ b/frontend/src/app/pages/admin-venue-verification-page.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState, useCallback } from 'react';
 import { useAdmin } from '@/app/contexts/admin-context';
 import { Button } from '@/app/components/ui/button';
 import { Badge } from '@/app/components/ui/badge';
+import { toast } from 'sonner';
 import {
   Select,
   SelectContent,
@@ -112,7 +113,7 @@ export function AdminVenueVerificationPage() {
           )
         );
       } else {
-        alert(data.error || 'Action failed');
+        toast.error(data.error || 'Action failed');
       }
     } catch (err) {
       console.error('Claim action error:', err);

--- a/frontend/src/app/pages/group-detail-page.tsx
+++ b/frontend/src/app/pages/group-detail-page.tsx
@@ -41,8 +41,19 @@ import {
   Mic,
   MicOff,
 } from "lucide-react";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/app/components/ui/alert-dialog";
 import { ChatSidebar } from "@/app/components/chat-sidebar";
 import { useState, useEffect } from "react";
+import { toast } from "sonner";
 
 export function GroupDetailPage() {
   const { groupId } = useParams();
@@ -82,6 +93,12 @@ export function GroupDetailPage() {
   const [minimumSanitationGrade, setMinimumSanitationGrade] = useState<string>('A');
   const [priceRange, setPriceRange] = useState<string>('any');
   const [savingConstraints, setSavingConstraints] = useState(false);
+  const [confirmDialog, setConfirmDialog] = useState<{
+    open: boolean;
+    title: string;
+    description: string;
+    onConfirm: () => void;
+  }>({ open: false, title: '', description: '', onConfirm: () => {} });
 
   const group = groups.find((g) => g.id === groupId);
   const groupEvents = swipeEvents.filter(
@@ -164,7 +181,7 @@ export function GroupDetailPage() {
     try {
       await regenerateJoinCode(group.id);
     } catch (e: unknown) {
-      alert("Failed to regenerate code: " + (e instanceof Error ? e.message : "Unknown error"));
+      toast.error("Failed to regenerate code: " + (e instanceof Error ? e.message : "Unknown error"));
     } finally {
       setRegeneratingCode(false);
     }
@@ -179,7 +196,7 @@ export function GroupDetailPage() {
       });
       setShowConstraintsDialog(false);
     } catch (e) {
-      alert((e as Error).message);
+      toast.error((e as Error).message);
     } finally {
       setSavingConstraints(false);
     }
@@ -245,16 +262,19 @@ export function GroupDetailPage() {
                 <Button
                   variant="outline"
                   className="text-red-500 hover:text-red-600 hover:bg-red-50 border-red-100 flex items-center gap-2"
-                  onClick={async () => {
-                    if (window.confirm("Are you sure you want to leave this group?")) {
+                  onClick={() => setConfirmDialog({
+                    open: true,
+                    title: "Leave group?",
+                    description: "Are you sure you want to leave this group?",
+                    onConfirm: async () => {
                       try {
                         await leaveGroup(group.id);
                         navigate("/home");
                       } catch (e) {
-                        alert((e as Error).message);
+                        toast.error((e as Error).message);
                       }
-                    }
-                  }}
+                    },
+                  })}
                 >
                   <span className="hidden sm:inline">Leave Group</span>
                   <span className="sm:hidden">Leave</span>
@@ -263,16 +283,19 @@ export function GroupDetailPage() {
                   <Button
                     variant="outline"
                     className="text-red-500 hover:text-red-600 hover:bg-red-50 border-red-100 flex items-center gap-2"
-                    onClick={async () => {
-                      if (window.confirm("Are you sure you want to delete this group?")) {
+                    onClick={() => setConfirmDialog({
+                      open: true,
+                      title: "Delete group?",
+                      description: "Are you sure you want to delete this group? This cannot be undone.",
+                      onConfirm: async () => {
                         try {
                           await deleteGroup(group.id);
                           navigate("/home");
                         } catch (e) {
-                          alert((e as Error).message);
+                          toast.error((e as Error).message);
                         }
-                      }
-                    }}
+                      },
+                    })}
                   >
                     <span className="hidden sm:inline">Delete Group</span>
                     <span className="sm:hidden">Delete</span>
@@ -466,15 +489,18 @@ export function GroupDetailPage() {
                                   variant="ghost" 
                                   size="sm" 
                                   className="h-8 px-2 text-xs"
-                                  onClick={async () => {
-                                    if (window.confirm(`Make ${member.userName} a leader?`)) {
+                                  onClick={() => setConfirmDialog({
+                                    open: true,
+                                    title: `Promote ${member.userName}?`,
+                                    description: `Make ${member.userName} a leader of this group?`,
+                                    onConfirm: async () => {
                                       try {
                                         await makeLeader(group.id, member.userId);
                                       } catch (e) {
-                                        alert((e as Error).message);
+                                        toast.error((e as Error).message);
                                       }
-                                    }
-                                  }}
+                                    },
+                                  })}
                                 >
                                   <Crown className="w-3 h-3 mr-1" />
                                   Promote
@@ -484,15 +510,18 @@ export function GroupDetailPage() {
                                 variant="ghost" 
                                 size="sm" 
                                 className="h-8 px-2 text-xs text-red-600 hover:text-red-700 hover:bg-red-50"
-                                onClick={async () => {
-                                  if (window.confirm(`Remove ${member.userName} from the group?`)) {
+                                onClick={() => setConfirmDialog({
+                                  open: true,
+                                  title: `Remove ${member.userName}?`,
+                                  description: `Remove ${member.userName} from this group?`,
+                                  onConfirm: async () => {
                                     try {
                                       await removeMember(group.id, member.userId);
                                     } catch (e) {
-                                      alert((e as Error).message);
+                                      toast.error((e as Error).message);
                                     }
-                                  }
-                                }}
+                                  },
+                                })}
                               >
                                 <X className="w-3 h-3 mr-1" />
                                 Remove
@@ -769,6 +798,30 @@ export function GroupDetailPage() {
           onClose={() => setShowChat(false)}
         />
       )}
+
+      <AlertDialog
+        open={confirmDialog.open}
+        onOpenChange={(open) => !open && setConfirmDialog((d) => ({ ...d, open: false }))}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>{confirmDialog.title}</AlertDialogTitle>
+            <AlertDialogDescription>{confirmDialog.description}</AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              className="bg-red-600 hover:bg-red-700 text-white"
+              onClick={() => {
+                setConfirmDialog((d) => ({ ...d, open: false }));
+                confirmDialog.onConfirm();
+              }}
+            >
+              Confirm
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </>
   );
 }

--- a/frontend/src/app/pages/group-detail-page.tsx
+++ b/frontend/src/app/pages/group-detail-page.tsx
@@ -99,6 +99,7 @@ export function GroupDetailPage() {
     description: string;
     onConfirm: () => Promise<void>;
   }>({ open: false, title: '', description: '', onConfirm: async () => {} });
+  const [isConfirming, setIsConfirming] = useState(false);
 
   const group = groups.find((g) => g.id === groupId);
   const groupEvents = swipeEvents.filter(
@@ -812,16 +813,20 @@ export function GroupDetailPage() {
             <AlertDialogCancel>Cancel</AlertDialogCancel>
             <AlertDialogAction
               className="bg-red-600 hover:bg-red-700 text-white"
+              disabled={isConfirming}
               onClick={async () => {
+                setIsConfirming(true);
                 setConfirmDialog((d) => ({ ...d, open: false }));
                 try {
                   await confirmDialog.onConfirm();
                 } catch (e) {
                   toast.error((e as Error).message);
+                } finally {
+                  setIsConfirming(false);
                 }
               }}
             >
-              Confirm
+              {isConfirming ? 'Confirming…' : 'Confirm'}
             </AlertDialogAction>
           </AlertDialogFooter>
         </AlertDialogContent>

--- a/frontend/src/app/pages/group-detail-page.tsx
+++ b/frontend/src/app/pages/group-detail-page.tsx
@@ -97,8 +97,8 @@ export function GroupDetailPage() {
     open: boolean;
     title: string;
     description: string;
-    onConfirm: () => void;
-  }>({ open: false, title: '', description: '', onConfirm: () => {} });
+    onConfirm: () => Promise<void>;
+  }>({ open: false, title: '', description: '', onConfirm: async () => {} });
 
   const group = groups.find((g) => g.id === groupId);
   const groupEvents = swipeEvents.filter(
@@ -812,9 +812,13 @@ export function GroupDetailPage() {
             <AlertDialogCancel>Cancel</AlertDialogCancel>
             <AlertDialogAction
               className="bg-red-600 hover:bg-red-700 text-white"
-              onClick={() => {
+              onClick={async () => {
                 setConfirmDialog((d) => ({ ...d, open: false }));
-                confirmDialog.onConfirm();
+                try {
+                  await confirmDialog.onConfirm();
+                } catch (e) {
+                  toast.error((e as Error).message);
+                }
               }}
             >
               Confirm

--- a/frontend/src/app/pages/login-page.test.tsx
+++ b/frontend/src/app/pages/login-page.test.tsx
@@ -1,14 +1,6 @@
 /**
  * Login page tests.
- * Cache invalidation comment
- *
  * Run: npm run test:run (from frontend/)
- *
- * Note: Under Vite 8 beta + Vitest, loading app code can trigger SSR-like transform
- * and cause __vite_ssr_exportName__ or undefined component errors. This is an
- * environment/configuration issue, not a bug in this test or app code. To run
- * these tests: use Vite 5 for tests (set "vite": "^5.4.11" in devDependencies) or
- * configure Vitest to disable SSR transform for tests. See docs/TEST_RESULTS.md.
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, within } from '@/test/test-utils';

--- a/frontend/src/app/pages/login-page.tsx
+++ b/frontend/src/app/pages/login-page.tsx
@@ -158,10 +158,7 @@ export function LoginPage() {
               Create New Account
             </Button>
 
-            <div className="text-center space-y-2">
-              <p className="text-sm text-muted-foreground">
-                Demo: Use alex@nyu.edu, sarah@nyu.edu, or jordan@nyu.edu
-              </p>
+            <div className="text-center">
               <button
                 type="button"
                 onClick={() => navigate('/venue/login')}

--- a/frontend/src/app/pages/register-page.test.tsx
+++ b/frontend/src/app/pages/register-page.test.tsx
@@ -1,11 +1,6 @@
 /**
  * Register page tests.
- *
  * Run: npm run test:run (from frontend/)
- *
- * Note: Under Vite 8 beta + Vitest, component tests may fail due to environment
- * (SSR-like transform), not due to this code. Use Vite 5 for tests or fix config;
- * see docs/TEST_RESULTS.md.
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen } from '@/test/test-utils';

--- a/frontend/src/app/pages/swipe-page.tsx
+++ b/frontend/src/app/pages/swipe-page.tsx
@@ -7,6 +7,7 @@ import { ChatSidebar } from "@/app/components/chat-sidebar";
 import { Button } from "@/app/components/ui/button";
 import { Progress } from "@/app/components/ui/progress";
 import { MessageCircle, Users } from "lucide-react";
+import { toast } from "sonner";
 
 export function SwipePage() {
   const { eventId } = useParams();
@@ -124,7 +125,7 @@ export function SwipePage() {
     } catch (error: unknown) {
       console.error("Failed to submit swipe:", error);
       if (error instanceof Error && error.message === "This event is no longer active") {
-        alert("A match has already been found for this session!");
+        toast.info("A match has already been found for this session!");
         navigate(`/match/${event.id}`);
         return;
       }

--- a/frontend/src/test/setup.ts
+++ b/frontend/src/test/setup.ts
@@ -4,7 +4,7 @@ import { afterEach, vi } from 'vitest';
 
 afterEach(() => {
   cleanup();
-  vi.clearAllMocks();
+  vi.restoreAllMocks(); // restores spies created with vi.spyOn, clears all mocks
 });
 
 // Default fetch mock so AppProvider's session check doesn't hit the network.

--- a/frontend/src/test/setup.ts
+++ b/frontend/src/test/setup.ts
@@ -2,19 +2,6 @@ import '@testing-library/jest-dom';
 import { cleanup } from '@testing-library/react';
 import { afterEach, vi } from 'vitest';
 
-// Workaround when Vitest loads app code with SSR-like transform (Vite 8 beta or config)
-(globalThis as unknown as Record<string, unknown>).__vite_ssr_exportName__ = function (
-  exports: unknown,
-  name: string,
-  getter: () => unknown
-) {
-  if (exports !== null && typeof exports === 'object') {
-    try {
-      Object.defineProperty(exports, name, { get: getter, enumerable: true });
-    } catch { /* intentionally ignored */ }
-  }
-};
-
 afterEach(() => {
   cleanup();
   vi.clearAllMocks();

--- a/frontend/src/test/smoke.test.ts
+++ b/frontend/src/test/smoke.test.ts
@@ -1,6 +1,5 @@
 /**
- * Minimal smoke test: Vitest and jsdom run; expect extensions work.
- * This passes even when full component tests hit Vite 8 beta SSR transform issues.
+ * Smoke test: confirms Vitest and jsdom are correctly configured.
  */
 import { describe, it, expect } from 'vitest';
 


### PR DESCRIPTION
WS1 — Remove @csrf_exempt (security)
Removed 45 @csrf_exempt decorators across accounts, groups, chat, and venues views. Django's CSRF middleware now protects all cookie-authenticated endpoints. Added 11 CSRF enforcement tests (accounts.CSRFProtectionTests) using Client(enforce_csrf_checks=True).

WS2 — Frontend test tooling cleanup
Removed Vite 8 beta workarounds that are no longer needed. All 20 frontend tests pass cleanly.

WS3 — Remove demo/localStorage seeding
Stripped ~240 lines of hardcoded fake-user state that seeded localStorage on every app load. Added a one-time legacy key cleanup effect. App now only loads real data from the API.

WS4 — Split oversized app-context.tsx
Extracted auth state into auth-context.tsx and shared fetch helpers into lib/api.ts. AppProvider now composes AuthProvider + AppInner. useApp() public API is unchanged — no component changes required. Removed duplicate getCookie/apiUrl implementations from venue-context and admin-context.

WS5 — Replace alert()/window.confirm()
Replaced all 5 blocking browser dialogs with toast (sonner) and AlertDialog (shadcn/ui) across group-detail-page, swipe-page, admin-venue-verification-page, and admin-venue-edit-page. Updated affected test to spy on toast.info instead of window.alert.

WS6 — Documentation cleanup
Replaced the Vite scaffold boilerplate in frontend/README.md with project-specific docs. Removed a stale "Vite 8 tests may not pass" warning from the root README. Added a CSRF test suite table to docs/TEST_RESULTS.md.

WS7 — Backend test speed
Added config/test_settings.py with MD5PasswordHasher (replaces PBKDF2-SHA256 at 260k rounds) and locmem email backend. Updated .travis.yml to use it. All 410 backend tests pass.