### PR TITLE
fix: increase nginx client_max_body_size to 10M for photo uploads

### DIFF
--- a/backend/.platform/nginx/conf.d/client_max_body_size.conf
+++ b/backend/.platform/nginx/conf.d/client_max_body_size.conf
@@ -1,0 +1,1 @@
+client_max_body_size 10M;


### PR DESCRIPTION
EB nginx defaults block multipart uploads with 413. Set 10M to match the 5MB app-level limit with room for multipart overhead.