### PR TITLE
Serve ASGI via Daphne and pass WebSocket upgrade through nginx

### DIFF
--- a/backend/.platform/nginx/conf.d/websocket.conf
+++ b/backend/.platform/nginx/conf.d/websocket.conf
@@ -1,0 +1,11 @@
+location /ws/ {
+    proxy_pass http://127.0.0.1:8000;
+    proxy_http_version 1.1;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection "upgrade";
+    proxy_set_header Host $host;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_read_timeout 3600s;
+    proxy_send_timeout 3600s;
+}

--- a/backend/Procfile
+++ b/backend/Procfile
@@ -1,1 +1,1 @@
-web: gunicorn config.wsgi:application --bind 0.0.0.0:8000
+web: daphne -b 0.0.0.0 -p 8000 config.asgi:application


### PR DESCRIPTION
Switch the backend Procfile from gunicorn (WSGI-only) to Daphne so the same process serves both HTTP and the /ws/notifications/ endpoint. Add an EB platform nginx config that forwards Upgrade/Connection headers and uses a long proxy timeout for the /ws/ location, so the WebSocket handshake reaches Daphne instead of being stripped at the proxy.