### PR TITLE
Fix role-based routing, session visibility, admin user search, and moderation queue

### DIFF
--- a/backend/accounts/tests.py
+++ b/backend/accounts/tests.py
@@ -1391,10 +1391,29 @@ class AdminUsersEndpointTests(TestCase):
         self.assertEqual(data["totalCount"], 1)
         self.assertEqual(data["users"][0]["username"], "alice_student")
 
+    def test_admin_users_search_by_username_only_match(self):
+        """Username matching is independent from email/name matching."""
+        self.student1.username = "zzz_only_username_match"
+        self.student1.save(update_fields=["username"])
+        res = self.client.get("/api/auth/admin/users/?q=zzz_only_username_match")
+        data = res.json()
+        self.assertEqual(data["totalCount"], 1)
+        self.assertEqual(data["users"][0]["id"], self.student1.id)
+
     def test_admin_users_short_query_does_not_filter(self):
         res = self.client.get("/api/auth/admin/users/?q=ali")
         data = res.json()
         self.assertEqual(data["totalCount"], 4)
+
+    def test_admin_users_query_exactly_three_chars_does_not_filter(self):
+        """Boundary: 'more than 3' means strictly > 3 chars."""
+        res = self.client.get("/api/auth/admin/users/?q=bob")
+        # 'bob' is 3 chars; would match bob@test.local if filtering kicked in
+        self.assertEqual(res.json()["totalCount"], 4)
+
+    def test_admin_users_query_four_chars_filters(self):
+        res = self.client.get("/api/auth/admin/users/?q=alic")
+        self.assertEqual(res.json()["totalCount"], 1)
 
     def test_admin_users_filter_by_role(self):
         res = self.client.get("/api/auth/admin/users/?role=student")

--- a/backend/accounts/tests.py
+++ b/backend/accounts/tests.py
@@ -1383,6 +1383,19 @@ class AdminUsersEndpointTests(TestCase):
         self.assertEqual(data["totalCount"], 1)
         self.assertEqual(data["users"][0]["lastName"], "Jones")
 
+    def test_admin_users_search_by_username_when_query_long_enough(self):
+        self.student1.username = "alice_student"
+        self.student1.save(update_fields=["username"])
+        res = self.client.get("/api/auth/admin/users/?q=alice")
+        data = res.json()
+        self.assertEqual(data["totalCount"], 1)
+        self.assertEqual(data["users"][0]["username"], "alice_student")
+
+    def test_admin_users_short_query_does_not_filter(self):
+        res = self.client.get("/api/auth/admin/users/?q=ali")
+        data = res.json()
+        self.assertEqual(data["totalCount"], 4)
+
     def test_admin_users_filter_by_role(self):
         res = self.client.get("/api/auth/admin/users/?role=student")
         data = res.json()
@@ -1403,6 +1416,7 @@ class AdminUsersEndpointTests(TestCase):
         u = res.json()["users"][0]
         for key in (
             "id",
+            "username",
             "email",
             "firstName",
             "lastName",

--- a/backend/accounts/views.py
+++ b/backend/accounts/views.py
@@ -833,6 +833,7 @@ def _require_admin(request):
 def _admin_user_row(user):
     return {
         "id": user.id,
+        "username": user.username,
         "email": user.email,
         "firstName": user.first_name,
         "lastName": user.last_name,
@@ -920,9 +921,10 @@ def api_admin_users_list(request):
 
     qs = User.objects.all().order_by("-created_at")
 
-    if q:
+    if len(q) > 3:
         qs = qs.filter(
             Q(email__icontains=q)
+            | Q(username__icontains=q)
             | Q(first_name__icontains=q)
             | Q(last_name__icontains=q)
         )

--- a/backend/groups/migrations/0012_swipeevent_scheduled_for.py
+++ b/backend/groups/migrations/0012_swipeevent_scheduled_for.py
@@ -1,0 +1,16 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("groups", "0011_swipeevent_venue_limit"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="swipeevent",
+            name="scheduled_for",
+            field=models.DateTimeField(blank=True, null=True),
+        ),
+    ]

--- a/backend/groups/models.py
+++ b/backend/groups/models.py
@@ -114,6 +114,7 @@ class SwipeEvent(models.Model):
     )
     borough = models.CharField(max_length=50, blank=True)
     neighborhood = models.CharField(max_length=100, blank=True)
+    scheduled_for = models.DateTimeField(null=True, blank=True)
     completed_by = models.ManyToManyField(
         settings.AUTH_USER_MODEL, blank=True, related_name="completed_swipe_events"
     )

--- a/backend/groups/tests.py
+++ b/backend/groups/tests.py
@@ -307,6 +307,65 @@ class SwipeEventAPITests(TestCase):
         event = SwipeEvent.objects.get(id=payload["event"]["id"])
         self.assertTrue(timezone.is_aware(event.scheduled_for))
 
+    def test_create_event_without_scheduled_for_is_none(self):
+        self.client.login(email="leader@nyu.edu", password="pass123")
+        response = self.client.post(
+            f"/api/groups/{self.group.id}/events/",
+            json.dumps({"name": "No Schedule"}),
+            content_type="application/json",
+        )
+        self.assertEqual(response.status_code, 201)
+        self.assertIsNone(response.json()["event"]["scheduled_for"])
+        event = SwipeEvent.objects.get(name="No Schedule")
+        self.assertIsNone(event.scheduled_for)
+
+    def test_create_event_with_invalid_scheduled_for_silently_drops(self):
+        """Backend tolerates an unparseable scheduled_for instead of erroring."""
+        self.client.login(email="leader@nyu.edu", password="pass123")
+        response = self.client.post(
+            f"/api/groups/{self.group.id}/events/",
+            json.dumps({"name": "Bad Date", "scheduled_for": "not-a-date"}),
+            content_type="application/json",
+        )
+        self.assertEqual(response.status_code, 201)
+        self.assertIsNone(response.json()["event"]["scheduled_for"])
+
+    def test_create_event_with_aware_scheduled_for_preserves_offset(self):
+        self.client.login(email="leader@nyu.edu", password="pass123")
+        response = self.client.post(
+            f"/api/groups/{self.group.id}/events/",
+            json.dumps(
+                {
+                    "name": "TZ Aware",
+                    "scheduled_for": "2026-05-01T19:30:00+00:00",
+                }
+            ),
+            content_type="application/json",
+        )
+        self.assertEqual(response.status_code, 201)
+        event = SwipeEvent.objects.get(name="TZ Aware")
+        self.assertTrue(timezone.is_aware(event.scheduled_for))
+
+    def test_event_list_includes_scheduled_for(self):
+        SwipeEvent.objects.create(
+            group=self.group,
+            name="Scheduled",
+            created_by=self.leader,
+            scheduled_for=timezone.make_aware(
+                __import__("datetime").datetime(2026, 6, 1, 18, 0)
+            ),
+            borough="Manhattan",
+            neighborhood="East Village",
+        )
+        self.client.login(email="leader@nyu.edu", password="pass123")
+        response = self.client.get(f"/api/groups/{self.group.id}/events/")
+        self.assertEqual(response.status_code, 200)
+        events = response.json()["events"]
+        scheduled = next(e for e in events if e["name"] == "Scheduled")
+        self.assertIsNotNone(scheduled["scheduled_for"])
+        self.assertEqual(scheduled["borough"], "Manhattan")
+        self.assertEqual(scheduled["neighborhood"], "East Village")
+
     def test_create_event_as_member_forbidden(self):
         self.client.login(email="member1@nyu.edu", password="pass123")
         response = self.client.post(

--- a/backend/groups/tests.py
+++ b/backend/groups/tests.py
@@ -4,6 +4,7 @@ from unittest.mock import patch
 from django.contrib.auth import get_user_model
 from django.test import TestCase, Client
 from django.urls import reverse
+from django.utils import timezone
 
 from accounts.models import UserPreference
 from chat.models import Chat, ChatMember, Message
@@ -98,17 +99,19 @@ class GroupAPITests(TestCase):
         )
 
         self.client.login(email="alice@example.com", password="password123")
-        response = self.client.post(
-            f"/api/groups/{group.id}/invite/",
-            json.dumps({"email": "bob@example.com"}),
-            content_type="application/json",
-        )
+        with patch("groups.views.send_mail") as send_mail_mock:
+            response = self.client.post(
+                f"/api/groups/{group.id}/invite/",
+                json.dumps({"email": "bob@example.com"}),
+                content_type="application/json",
+            )
         self.assertEqual(response.status_code, 200)
         self.assertTrue(
             GroupInvitation.objects.filter(
                 invitee=self.user2, group=group, status="pending"
             ).exists()
         )
+        send_mail_mock.assert_called_once()
 
     def test_cannot_leave_if_only_leader(self):
         group = Group.objects.create(name="Solo Club", created_by=self.user1)
@@ -284,6 +287,25 @@ class SwipeEventAPITests(TestCase):
         self.assertTrue(data["success"])
         self.assertEqual(data["event"]["name"], "Friday Dinner")
         self.assertEqual(data["event"]["status"], "active")
+
+    def test_create_event_with_scheduled_for(self):
+        self.client.login(email="leader@nyu.edu", password="pass123")
+        response = self.client.post(
+            f"/api/groups/{self.group.id}/events/",
+            json.dumps(
+                {
+                    "name": "Timed Session",
+                    "scheduled_for": "2026-05-01T19:30:00",
+                }
+            ),
+            content_type="application/json",
+        )
+        self.assertEqual(response.status_code, 201)
+        payload = response.json()
+        self.assertIn("scheduled_for", payload["event"])
+        self.assertIsNotNone(payload["event"]["scheduled_for"])
+        event = SwipeEvent.objects.get(id=payload["event"]["id"])
+        self.assertTrue(timezone.is_aware(event.scheduled_for))
 
     def test_create_event_as_member_forbidden(self):
         self.client.login(email="member1@nyu.edu", password="pass123")

--- a/backend/groups/views.py
+++ b/backend/groups/views.py
@@ -1,6 +1,7 @@
 import json
 import logging
 import math
+from datetime import datetime
 from django.http import JsonResponse
 from django.contrib.auth import get_user_model
 from django.db import transaction, models
@@ -8,6 +9,8 @@ from django.db.models import Count, prefetch_related_objects
 from django.core.exceptions import ValidationError
 from django.core.validators import validate_email
 from django.utils import timezone
+from django.core.mail import send_mail
+from django.conf import settings
 
 from .models import Group, GroupMembership, SwipeEvent, Swipe, GroupInvitation
 from venues.models import Venue, VenuePhoto
@@ -343,6 +346,28 @@ def api_invite_to_group(request, group_id):
         )
         if not created:
             return JsonResponse({"error": "User has already been invited"}, status=400)
+
+        inviter_name = (
+            f"{request.user.first_name} {request.user.last_name}".strip()
+            or request.user.email
+        )
+        try:
+            send_mail(
+                subject=f"You were invited to join {group.name}",
+                message=(
+                    f"{inviter_name} invited you to join the group \"{group.name}\" on MealSwipe.\n"
+                    "Sign in to view and respond to your invitation."
+                ),
+                from_email=settings.DEFAULT_FROM_EMAIL,
+                recipient_list=[target_user.email],
+                fail_silently=True,
+            )
+        except Exception:
+            logger.warning(
+                "Failed to send invitation email to user_id=%s",
+                target_user.id,
+                exc_info=True,
+            )
 
         from channels.layers import get_channel_layer
         from asgiref.sync import async_to_sync
@@ -722,10 +747,27 @@ def _event_to_json(event):
         "matched_venue_id": event.matched_venue_id,
         "borough": event.borough,
         "neighborhood": event.neighborhood,
+        "scheduled_for": event.scheduled_for.isoformat() if event.scheduled_for else None,
         "created_at": event.created_at.isoformat(),
         "total_participants": event.group.memberships.count(),
         "completed_participants_count": event.completed_by.count(),
     }
+
+
+def _parse_scheduled_for(raw_value):
+    """Parse optional ISO datetime from API payload to timezone-aware datetime."""
+    if not raw_value or not isinstance(raw_value, str):
+        return None
+    value = raw_value.strip()
+    if not value:
+        return None
+    try:
+        parsed = datetime.fromisoformat(value)
+    except ValueError:
+        return None
+    if timezone.is_naive(parsed):
+        return timezone.make_aware(parsed, timezone.get_current_timezone())
+    return parsed
 
 
 def _venue_to_swipe_json(venue):
@@ -858,6 +900,7 @@ def api_swipe_events(request, group_id):
                 created_by=request.user,
                 borough=(data.get("borough") or "").strip(),
                 neighborhood=(data.get("neighborhood") or "").strip(),
+                scheduled_for=_parse_scheduled_for(data.get("scheduled_for")),
                 venue_limit=int(data.get("venue_limit", 10)),
             )
 

--- a/backend/groups/views.py
+++ b/backend/groups/views.py
@@ -355,7 +355,7 @@ def api_invite_to_group(request, group_id):
             send_mail(
                 subject=f"You were invited to join {group.name}",
                 message=(
-                    f"{inviter_name} invited you to join the group \"{group.name}\" on MealSwipe.\n"
+                    f'{inviter_name} invited you to join the group "{group.name}" on MealSwipe.\n'
                     "Sign in to view and respond to your invitation."
                 ),
                 from_email=settings.DEFAULT_FROM_EMAIL,
@@ -747,7 +747,9 @@ def _event_to_json(event):
         "matched_venue_id": event.matched_venue_id,
         "borough": event.borough,
         "neighborhood": event.neighborhood,
-        "scheduled_for": event.scheduled_for.isoformat() if event.scheduled_for else None,
+        "scheduled_for": (
+            event.scheduled_for.isoformat() if event.scheduled_for else None
+        ),
         "created_at": event.created_at.isoformat(),
         "total_participants": event.group.memberships.count(),
         "completed_participants_count": event.completed_by.count(),

--- a/backend/venues/migrations/0006_contentreport.py
+++ b/backend/venues/migrations/0006_contentreport.py
@@ -14,16 +14,69 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             name="ContentReport",
             fields=[
-                ("id", models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name="ID")),
+                (
+                    "id",
+                    models.BigAutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name="ID",
+                    ),
+                ),
                 ("reason", models.TextField()),
-                ("status", models.CharField(choices=[("pending", "Pending"), ("confirmed", "Confirmed"), ("rejected", "Rejected")], default="pending", max_length=20)),
+                (
+                    "status",
+                    models.CharField(
+                        choices=[
+                            ("pending", "Pending"),
+                            ("confirmed", "Confirmed"),
+                            ("rejected", "Rejected"),
+                        ],
+                        default="pending",
+                        max_length=20,
+                    ),
+                ),
                 ("reviewed_at", models.DateTimeField(blank=True, null=True)),
                 ("created_at", models.DateTimeField(auto_now_add=True)),
                 ("updated_at", models.DateTimeField(auto_now=True)),
-                ("comment", models.ForeignKey(blank=True, null=True, on_delete=django.db.models.deletion.CASCADE, related_name="reports", to="venues.reviewcomment")),
-                ("reporter", models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name="content_reports", to=settings.AUTH_USER_MODEL)),
-                ("review", models.ForeignKey(blank=True, null=True, on_delete=django.db.models.deletion.CASCADE, related_name="reports", to="venues.review")),
-                ("reviewed_by", models.ForeignKey(blank=True, null=True, on_delete=django.db.models.deletion.SET_NULL, related_name="reviewed_content_reports", to=settings.AUTH_USER_MODEL)),
+                (
+                    "comment",
+                    models.ForeignKey(
+                        blank=True,
+                        null=True,
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="reports",
+                        to="venues.reviewcomment",
+                    ),
+                ),
+                (
+                    "reporter",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="content_reports",
+                        to=settings.AUTH_USER_MODEL,
+                    ),
+                ),
+                (
+                    "review",
+                    models.ForeignKey(
+                        blank=True,
+                        null=True,
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="reports",
+                        to="venues.review",
+                    ),
+                ),
+                (
+                    "reviewed_by",
+                    models.ForeignKey(
+                        blank=True,
+                        null=True,
+                        on_delete=django.db.models.deletion.SET_NULL,
+                        related_name="reviewed_content_reports",
+                        to=settings.AUTH_USER_MODEL,
+                    ),
+                ),
             ],
             options={
                 "ordering": ["-created_at"],
@@ -32,7 +85,11 @@ class Migration(migrations.Migration):
         migrations.AddConstraint(
             model_name="contentreport",
             constraint=models.CheckConstraint(
-                check=models.Q(models.Q(("review__isnull", False), ("comment__isnull", True)), models.Q(("review__isnull", True), ("comment__isnull", False)), _connector="OR"),
+                check=models.Q(
+                    models.Q(("review__isnull", False), ("comment__isnull", True)),
+                    models.Q(("review__isnull", True), ("comment__isnull", False)),
+                    _connector="OR",
+                ),
                 name="content_report_exactly_one_target",
             ),
         ),

--- a/backend/venues/migrations/0006_contentreport.py
+++ b/backend/venues/migrations/0006_contentreport.py
@@ -1,0 +1,39 @@
+from django.conf import settings
+from django.db import migrations, models
+import django.db.models.deletion
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("venues", "0005_alter_venuephoto_image_url"),
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name="ContentReport",
+            fields=[
+                ("id", models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name="ID")),
+                ("reason", models.TextField()),
+                ("status", models.CharField(choices=[("pending", "Pending"), ("confirmed", "Confirmed"), ("rejected", "Rejected")], default="pending", max_length=20)),
+                ("reviewed_at", models.DateTimeField(blank=True, null=True)),
+                ("created_at", models.DateTimeField(auto_now_add=True)),
+                ("updated_at", models.DateTimeField(auto_now=True)),
+                ("comment", models.ForeignKey(blank=True, null=True, on_delete=django.db.models.deletion.CASCADE, related_name="reports", to="venues.reviewcomment")),
+                ("reporter", models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name="content_reports", to=settings.AUTH_USER_MODEL)),
+                ("review", models.ForeignKey(blank=True, null=True, on_delete=django.db.models.deletion.CASCADE, related_name="reports", to="venues.review")),
+                ("reviewed_by", models.ForeignKey(blank=True, null=True, on_delete=django.db.models.deletion.SET_NULL, related_name="reviewed_content_reports", to=settings.AUTH_USER_MODEL)),
+            ],
+            options={
+                "ordering": ["-created_at"],
+            },
+        ),
+        migrations.AddConstraint(
+            model_name="contentreport",
+            constraint=models.CheckConstraint(
+                check=models.Q(models.Q(("review__isnull", False), ("comment__isnull", True)), models.Q(("review__isnull", True), ("comment__isnull", False)), _connector="OR"),
+                name="content_report_exactly_one_target",
+            ),
+        ),
+    ]

--- a/backend/venues/migrations/0007_review_additional_photos.py
+++ b/backend/venues/migrations/0007_review_additional_photos.py
@@ -1,0 +1,16 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("venues", "0006_contentreport"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="review",
+            name="additional_photos",
+            field=models.JSONField(blank=True, default=list),
+        ),
+    ]

--- a/backend/venues/models.py
+++ b/backend/venues/models.py
@@ -355,5 +355,9 @@ class ContentReport(models.Model):
         ordering = ["-created_at"]
 
     def __str__(self):
-        target = f"review:{self.review_id}" if self.review_id else f"comment:{self.comment_id}"
+        target = (
+            f"review:{self.review_id}"
+            if self.review_id
+            else f"comment:{self.comment_id}"
+        )
         return f"{self.reporter.email} reported {target} ({self.status})"

--- a/backend/venues/models.py
+++ b/backend/venues/models.py
@@ -232,6 +232,7 @@ class Review(models.Model):
     rating = models.PositiveSmallIntegerField()  # 1 to 5
     title = models.CharField(max_length=255, blank=True)
     content = models.TextField(blank=True)
+    additional_photos = models.JSONField(default=list, blank=True)
     visit_date = models.DateField()
     is_flagged = models.BooleanField(default=False)
     is_visible = models.BooleanField(default=True)

--- a/backend/venues/models.py
+++ b/backend/venues/models.py
@@ -296,3 +296,64 @@ class ReviewComment(models.Model):
 
     def __str__(self):
         return f"Comment by {self.user.email} on review {self.review.id}"
+
+
+class ContentReport(models.Model):
+    """User-submitted moderation reports for reviews and review comments."""
+
+    class Status(models.TextChoices):
+        PENDING = "pending", "Pending"
+        CONFIRMED = "confirmed", "Confirmed"
+        REJECTED = "rejected", "Rejected"
+
+    review = models.ForeignKey(
+        Review,
+        on_delete=models.CASCADE,
+        null=True,
+        blank=True,
+        related_name="reports",
+    )
+    comment = models.ForeignKey(
+        ReviewComment,
+        on_delete=models.CASCADE,
+        null=True,
+        blank=True,
+        related_name="reports",
+    )
+    reporter = models.ForeignKey(
+        settings.AUTH_USER_MODEL,
+        on_delete=models.CASCADE,
+        related_name="content_reports",
+    )
+    reason = models.TextField()
+    status = models.CharField(
+        max_length=20,
+        choices=Status.choices,
+        default=Status.PENDING,
+    )
+    reviewed_by = models.ForeignKey(
+        settings.AUTH_USER_MODEL,
+        on_delete=models.SET_NULL,
+        null=True,
+        blank=True,
+        related_name="reviewed_content_reports",
+    )
+    reviewed_at = models.DateTimeField(null=True, blank=True)
+    created_at = models.DateTimeField(auto_now_add=True)
+    updated_at = models.DateTimeField(auto_now=True)
+
+    class Meta:
+        constraints = [
+            models.CheckConstraint(
+                check=(
+                    (models.Q(review__isnull=False) & models.Q(comment__isnull=True))
+                    | (models.Q(review__isnull=True) & models.Q(comment__isnull=False))
+                ),
+                name="content_report_exactly_one_target",
+            )
+        ]
+        ordering = ["-created_at"]
+
+    def __str__(self):
+        target = f"review:{self.review_id}" if self.review_id else f"comment:{self.comment_id}"
+        return f"{self.reporter.email} reported {target} ({self.status})"

--- a/backend/venues/tests.py
+++ b/backend/venues/tests.py
@@ -1593,6 +1593,134 @@ class ModerationWorkflowTests(TestCase):
         self.assertEqual(first["reporter"]["email"], "reporter@nyu.edu")
 
 
+class VenueReviewApiTests(TestCase):
+    def setUp(self):
+        self.client = Client()
+        self.venue = Venue.objects.create(name="Review Venue")
+        self.student = User.objects.create_user(
+            email="student@nyu.edu", password="pass"
+        )
+        self.other_student = User.objects.create_user(
+            email="other@nyu.edu", password="pass"
+        )
+        self.manager_user = User.objects.create_user(
+            email="manager@nyu.edu", password="pass", role="venue_manager"
+        )
+        self.manager_profile = VenueManagerProfile.objects.create(
+            user=self.manager_user,
+            business_name="Review Venue LLC",
+            business_email="manager@nyu.edu",
+        )
+        self.venue.managed_by = self.manager_profile
+        self.venue.save(update_fields=["managed_by", "updated_at"])
+
+        self.visible_review = Review.objects.create(
+            venue=self.venue,
+            user=self.student,
+            rating=5,
+            title="Great",
+            content="Really solid food.",
+            visit_date=datetime.date(2025, 1, 12),
+            additional_photos=["https://example.com/review-photo.jpg"],
+        )
+        self.hidden_review = Review.objects.create(
+            venue=self.venue,
+            user=self.other_student,
+            rating=2,
+            title="Hidden",
+            content="This should not show publicly.",
+            visit_date=datetime.date(2025, 1, 13),
+            is_visible=False,
+            is_flagged=True,
+        )
+        self.owner_comment = ReviewComment.objects.create(
+            review=self.visible_review,
+            user=self.manager_user,
+            content="Thanks for coming in!",
+            is_manager_response=True,
+        )
+
+    def test_public_review_list_excludes_hidden_reviews(self):
+        res = self.client.get(reverse("venue_reviews", args=[self.venue.id]))
+        self.assertEqual(res.status_code, 200)
+        payload = res.json()
+        self.assertTrue(payload["success"])
+        self.assertFalse(payload["canReply"])
+        self.assertEqual(payload["venue"]["name"], "Review Venue")
+        self.assertEqual(len(payload["reviews"]), 1)
+        review = payload["reviews"][0]
+        self.assertEqual(review["title"], "Great")
+        self.assertEqual(
+            review["additionalPhotos"], ["https://example.com/review-photo.jpg"]
+        )
+        self.assertEqual(len(review["comments"]), 1)
+        self.assertTrue(review["comments"][0]["isManagerResponse"])
+
+    def test_manager_can_view_hidden_reviews_for_owned_venue(self):
+        self.client.force_login(self.manager_user)
+        res = self.client.get(reverse("venue_reviews", args=[self.venue.id]))
+        self.assertEqual(res.status_code, 200)
+        payload = res.json()
+        self.assertTrue(payload["canReply"])
+        self.assertEqual(len(payload["reviews"]), 2)
+        hidden = next(
+            review for review in payload["reviews"] if review["title"] == "Hidden"
+        )
+        self.assertFalse(hidden["isVisible"])
+
+    def test_student_can_create_review_with_photos(self):
+        self.client.force_login(self.student)
+        res = self.client.post(
+            reverse("venue_reviews", args=[self.venue.id]),
+            data=json.dumps(
+                {
+                    "rating": 4,
+                    "title": "Good meal",
+                    "content": "Would come back.",
+                    "visitDate": "2025-02-14",
+                    "additionalPhotos": [
+                        "https://example.com/a.jpg",
+                        "https://example.com/b.jpg",
+                    ],
+                }
+            ),
+            content_type="application/json",
+        )
+        self.assertEqual(res.status_code, 201)
+        review = Review.objects.get(title="Good meal")
+        self.assertEqual(review.user, self.student)
+        self.assertEqual(
+            review.additional_photos,
+            ["https://example.com/a.jpg", "https://example.com/b.jpg"],
+        )
+        self.assertTrue(review.is_visible)
+
+    def test_manager_can_reply_to_review_as_owner_response(self):
+        self.client.force_login(self.manager_user)
+        res = self.client.post(
+            reverse(
+                "venue_review_comment", args=[self.venue.id, self.visible_review.id]
+            ),
+            data=json.dumps({"content": "We appreciate the feedback."}),
+            content_type="application/json",
+        )
+        self.assertEqual(res.status_code, 201)
+        comment = ReviewComment.objects.get(content="We appreciate the feedback.")
+        self.assertTrue(comment.is_manager_response)
+        self.assertEqual(comment.user, self.manager_user)
+
+    def test_non_manager_cannot_reply_to_review(self):
+        self.client.force_login(self.student)
+        res = self.client.post(
+            reverse(
+                "venue_review_comment", args=[self.venue.id, self.visible_review.id]
+            ),
+            data=json.dumps({"content": "Not allowed"}),
+            content_type="application/json",
+        )
+        self.assertEqual(res.status_code, 403)
+
+
 class StrictPreferenceFilterTest(TestCase):
     """Covers the STRICT_PREFERENCE_FILTERS toggle in filter_venues_by_preferences.
 

--- a/backend/venues/tests.py
+++ b/backend/venues/tests.py
@@ -1527,7 +1527,9 @@ class ModerationWorkflowTests(TestCase):
             role="admin",
             is_staff=True,
         )
-        self.reporter = User.objects.create_user(email="reporter@nyu.edu", password="pass")
+        self.reporter = User.objects.create_user(
+            email="reporter@nyu.edu", password="pass"
+        )
         self.author = User.objects.create_user(email="author@nyu.edu", password="pass")
         self.venue = Venue.objects.create(name="Queue Venue")
         self.review = Review.objects.create(

--- a/backend/venues/tests.py
+++ b/backend/venues/tests.py
@@ -1960,9 +1960,7 @@ class AdminModerationActionExtraTests(TestCase):
         self.reporter = User.objects.create_user(
             email="reporter2@nyu.edu", password="pass"
         )
-        self.author = User.objects.create_user(
-            email="author2@nyu.edu", password="pass"
-        )
+        self.author = User.objects.create_user(email="author2@nyu.edu", password="pass")
         self.venue = Venue.objects.create(name="Action Venue")
         self.review = Review.objects.create(
             venue=self.venue,

--- a/backend/venues/tests.py
+++ b/backend/venues/tests.py
@@ -11,6 +11,7 @@ from django.core.management import call_command
 from django.db import IntegrityError
 from django.test import TestCase, override_settings, Client
 from django.urls import reverse
+from django.utils import timezone
 
 from accounts.models import (
     CuisineType,
@@ -1719,6 +1720,448 @@ class VenueReviewApiTests(TestCase):
             content_type="application/json",
         )
         self.assertEqual(res.status_code, 403)
+
+
+class VenueReviewApiValidationTests(TestCase):
+    """Covers POST /api/venues/<id>/reviews/ input validation branches."""
+
+    def setUp(self):
+        self.client = Client()
+        self.venue = Venue.objects.create(name="Validation Venue")
+        self.student = User.objects.create_user(
+            email="student-v@nyu.edu", password="pass"
+        )
+        self.manager_user = User.objects.create_user(
+            email="manager-v@nyu.edu", password="pass", role="venue_manager"
+        )
+
+    def _post(self, payload):
+        return self.client.post(
+            reverse("venue_reviews", args=[self.venue.id]),
+            data=json.dumps(payload),
+            content_type="application/json",
+        )
+
+    def test_anonymous_cannot_create_review(self):
+        res = self._post(
+            {"rating": 5, "visitDate": "2025-02-01", "title": "x", "content": "y"}
+        )
+        self.assertEqual(res.status_code, 401)
+
+    def test_manager_cannot_create_review(self):
+        self.client.force_login(self.manager_user)
+        res = self._post(
+            {"rating": 5, "visitDate": "2025-02-01", "title": "x", "content": "y"}
+        )
+        self.assertEqual(res.status_code, 403)
+
+    def test_missing_rating_returns_400(self):
+        self.client.force_login(self.student)
+        res = self._post({"visitDate": "2025-02-01"})
+        self.assertEqual(res.status_code, 400)
+        self.assertIn("Rating", res.json()["error"])
+
+    def test_rating_out_of_range_returns_400(self):
+        self.client.force_login(self.student)
+        res = self._post({"rating": 7, "visitDate": "2025-02-01"})
+        self.assertEqual(res.status_code, 400)
+        res = self._post({"rating": 0, "visitDate": "2025-02-01"})
+        self.assertEqual(res.status_code, 400)
+
+    def test_invalid_visit_date_returns_400(self):
+        self.client.force_login(self.student)
+        res = self._post({"rating": 4, "visitDate": "not-a-date"})
+        self.assertEqual(res.status_code, 400)
+        self.assertIn("visitDate", res.json()["error"])
+
+    def test_invalid_json_returns_400(self):
+        self.client.force_login(self.student)
+        res = self.client.post(
+            reverse("venue_reviews", args=[self.venue.id]),
+            data="{not-json",
+            content_type="application/json",
+        )
+        self.assertEqual(res.status_code, 400)
+
+    def test_non_list_photos_returns_400(self):
+        self.client.force_login(self.student)
+        res = self._post(
+            {
+                "rating": 4,
+                "visitDate": "2025-02-01",
+                "additionalPhotos": "https://example.com/a.jpg",
+            }
+        )
+        self.assertEqual(res.status_code, 400)
+        self.assertIn("list", res.json()["error"])
+
+    def test_too_many_photos_returns_400(self):
+        self.client.force_login(self.student)
+        res = self._post(
+            {
+                "rating": 4,
+                "visitDate": "2025-02-01",
+                "additionalPhotos": [f"https://example.com/{i}.jpg" for i in range(6)],
+            }
+        )
+        self.assertEqual(res.status_code, 400)
+
+    def test_blank_and_non_string_photos_are_filtered(self):
+        self.client.force_login(self.student)
+        res = self._post(
+            {
+                "rating": 4,
+                "visitDate": "2025-02-01",
+                "additionalPhotos": [
+                    "  https://example.com/a.jpg  ",
+                    "",
+                    None,
+                    42,
+                    "https://example.com/b.jpg",
+                ],
+            }
+        )
+        self.assertEqual(res.status_code, 201)
+        review = Review.objects.get(venue=self.venue, user=self.student)
+        self.assertEqual(
+            review.additional_photos,
+            ["https://example.com/a.jpg", "https://example.com/b.jpg"],
+        )
+
+    def test_inactive_venue_returns_404(self):
+        self.venue.is_active = False
+        self.venue.save(update_fields=["is_active", "updated_at"])
+        self.client.force_login(self.student)
+        res = self._post({"rating": 4, "visitDate": "2025-02-01"})
+        self.assertEqual(res.status_code, 404)
+
+    def test_method_not_allowed(self):
+        self.client.force_login(self.student)
+        res = self.client.delete(reverse("venue_reviews", args=[self.venue.id]))
+        self.assertEqual(res.status_code, 405)
+
+
+class ContentReportApiTests(TestCase):
+    """Covers user-facing report endpoints for reviews and comments."""
+
+    def setUp(self):
+        self.client = Client()
+        self.venue = Venue.objects.create(name="Report Venue")
+        self.author = User.objects.create_user(
+            email="author-r@nyu.edu", password="pass"
+        )
+        self.reporter = User.objects.create_user(
+            email="reporter-r@nyu.edu", password="pass"
+        )
+        self.review = Review.objects.create(
+            venue=self.venue,
+            user=self.author,
+            rating=3,
+            title="Hmm",
+            content="Body",
+            visit_date=datetime.date(2025, 1, 5),
+        )
+        self.comment = ReviewComment.objects.create(
+            review=self.review,
+            user=self.author,
+            content="Some comment",
+        )
+
+    def test_anonymous_cannot_report_review(self):
+        res = self.client.post(
+            reverse("report_review", args=[self.review.id]),
+            data=json.dumps({"reason": "spam"}),
+            content_type="application/json",
+        )
+        self.assertEqual(res.status_code, 401)
+
+    def test_report_review_requires_reason(self):
+        self.client.force_login(self.reporter)
+        res = self.client.post(
+            reverse("report_review", args=[self.review.id]),
+            data=json.dumps({"reason": "  "}),
+            content_type="application/json",
+        )
+        self.assertEqual(res.status_code, 400)
+        self.assertEqual(ContentReport.objects.count(), 0)
+
+    def test_report_review_invalid_json_returns_400(self):
+        self.client.force_login(self.reporter)
+        res = self.client.post(
+            reverse("report_review", args=[self.review.id]),
+            data="not-json",
+            content_type="application/json",
+        )
+        self.assertEqual(res.status_code, 400)
+
+    def test_report_review_missing_target_returns_404(self):
+        self.client.force_login(self.reporter)
+        res = self.client.post(
+            reverse("report_review", args=[99999]),
+            data=json.dumps({"reason": "spam"}),
+            content_type="application/json",
+        )
+        self.assertEqual(res.status_code, 404)
+
+    def test_report_review_method_not_allowed(self):
+        self.client.force_login(self.reporter)
+        res = self.client.get(reverse("report_review", args=[self.review.id]))
+        self.assertEqual(res.status_code, 405)
+
+    def test_report_comment_creates_pending_report_and_flags(self):
+        self.client.force_login(self.reporter)
+        res = self.client.post(
+            reverse("report_review_comment", args=[self.comment.id]),
+            data=json.dumps({"reason": "Personal attack"}),
+            content_type="application/json",
+        )
+        self.assertEqual(res.status_code, 201)
+        self.comment.refresh_from_db()
+        self.assertTrue(self.comment.is_flagged)
+        report = ContentReport.objects.get(comment=self.comment)
+        self.assertEqual(report.status, ContentReport.Status.PENDING)
+        self.assertIsNone(report.review_id)
+
+    def test_report_comment_anonymous(self):
+        res = self.client.post(
+            reverse("report_review_comment", args=[self.comment.id]),
+            data=json.dumps({"reason": "spam"}),
+            content_type="application/json",
+        )
+        self.assertEqual(res.status_code, 401)
+
+    def test_report_comment_missing_reason(self):
+        self.client.force_login(self.reporter)
+        res = self.client.post(
+            reverse("report_review_comment", args=[self.comment.id]),
+            data=json.dumps({}),
+            content_type="application/json",
+        )
+        self.assertEqual(res.status_code, 400)
+
+    def test_report_comment_missing_target_returns_404(self):
+        self.client.force_login(self.reporter)
+        res = self.client.post(
+            reverse("report_review_comment", args=[99999]),
+            data=json.dumps({"reason": "spam"}),
+            content_type="application/json",
+        )
+        self.assertEqual(res.status_code, 404)
+
+
+class AdminModerationActionExtraTests(TestCase):
+    """Covers branches in api_admin_moderation_action / queue beyond the smoke test."""
+
+    def setUp(self):
+        self.client = Client()
+        self.admin = User.objects.create_user(
+            email="admin2@nyu.edu", password="pass", role="admin", is_staff=True
+        )
+        self.reporter = User.objects.create_user(
+            email="reporter2@nyu.edu", password="pass"
+        )
+        self.author = User.objects.create_user(
+            email="author2@nyu.edu", password="pass"
+        )
+        self.venue = Venue.objects.create(name="Action Venue")
+        self.review = Review.objects.create(
+            venue=self.venue,
+            user=self.author,
+            rating=2,
+            title="X",
+            content="Y",
+            visit_date=datetime.date(2025, 3, 1),
+        )
+        self.comment = ReviewComment.objects.create(
+            review=self.review,
+            user=self.author,
+            content="A comment",
+        )
+        self.review_report = ContentReport.objects.create(
+            review=self.review, reporter=self.reporter, reason="bad review"
+        )
+        self.comment_report = ContentReport.objects.create(
+            comment=self.comment, reporter=self.reporter, reason="bad comment"
+        )
+
+    def test_queue_requires_admin(self):
+        res = self.client.get(reverse("admin_moderation_queue"))
+        self.assertEqual(res.status_code, 401)
+        self.client.force_login(self.reporter)
+        res = self.client.get(reverse("admin_moderation_queue"))
+        self.assertEqual(res.status_code, 403)
+
+    def test_queue_method_not_allowed(self):
+        self.client.force_login(self.admin)
+        res = self.client.post(reverse("admin_moderation_queue"))
+        self.assertEqual(res.status_code, 405)
+
+    def test_queue_filters_by_status(self):
+        self.review_report.status = ContentReport.Status.CONFIRMED
+        self.review_report.save(update_fields=["status", "updated_at"])
+        self.client.force_login(self.admin)
+        res = self.client.get(reverse("admin_moderation_queue") + "?status=confirmed")
+        payload = res.json()
+        self.assertEqual(payload["totalCount"], 1)
+        self.assertEqual(payload["reports"][0]["status"], "confirmed")
+
+    def test_queue_unknown_status_returns_all(self):
+        self.client.force_login(self.admin)
+        res = self.client.get(reverse("admin_moderation_queue") + "?status=bogus")
+        self.assertEqual(res.json()["totalCount"], 2)
+
+    def test_queue_pagination_clamps_page(self):
+        self.client.force_login(self.admin)
+        res = self.client.get(reverse("admin_moderation_queue") + "?page=99")
+        payload = res.json()
+        self.assertEqual(payload["page"], payload["totalPages"])
+
+    def test_action_requires_admin(self):
+        res = self.client.post(
+            reverse("admin_moderation_action", args=[self.review_report.id]),
+            data=json.dumps({"action": "confirm"}),
+            content_type="application/json",
+        )
+        self.assertEqual(res.status_code, 401)
+
+    def test_action_invalid_action_returns_400(self):
+        self.client.force_login(self.admin)
+        res = self.client.post(
+            reverse("admin_moderation_action", args=[self.review_report.id]),
+            data=json.dumps({"action": "maybe"}),
+            content_type="application/json",
+        )
+        self.assertEqual(res.status_code, 400)
+
+    def test_action_invalid_json_returns_400(self):
+        self.client.force_login(self.admin)
+        res = self.client.post(
+            reverse("admin_moderation_action", args=[self.review_report.id]),
+            data="not-json",
+            content_type="application/json",
+        )
+        self.assertEqual(res.status_code, 400)
+
+    def test_action_unknown_report_returns_404(self):
+        self.client.force_login(self.admin)
+        res = self.client.post(
+            reverse("admin_moderation_action", args=[99999]),
+            data=json.dumps({"action": "confirm"}),
+            content_type="application/json",
+        )
+        self.assertEqual(res.status_code, 404)
+
+    def test_action_method_not_allowed(self):
+        self.client.force_login(self.admin)
+        res = self.client.get(
+            reverse("admin_moderation_action", args=[self.review_report.id])
+        )
+        self.assertEqual(res.status_code, 405)
+
+    def test_confirm_comment_hides_comment_and_emails_author(self):
+        self.client.force_login(self.admin)
+        with patch("venues.views.send_mail") as send_mail_mock:
+            res = self.client.post(
+                reverse("admin_moderation_action", args=[self.comment_report.id]),
+                data=json.dumps({"action": "confirm"}),
+                content_type="application/json",
+            )
+        self.assertEqual(res.status_code, 200)
+        self.comment_report.refresh_from_db()
+        self.comment.refresh_from_db()
+        self.assertEqual(self.comment_report.status, ContentReport.Status.CONFIRMED)
+        self.assertFalse(self.comment.is_visible)
+        self.assertTrue(self.comment.is_flagged)
+        send_mail_mock.assert_called_once()
+
+    def test_reject_review_report_unflags_and_restores_visibility(self):
+        self.review.is_flagged = True
+        self.review.save(update_fields=["is_flagged", "updated_at"])
+        self.client.force_login(self.admin)
+        with patch("venues.views.send_mail") as send_mail_mock:
+            res = self.client.post(
+                reverse("admin_moderation_action", args=[self.review_report.id]),
+                data=json.dumps({"action": "reject"}),
+                content_type="application/json",
+            )
+        self.assertEqual(res.status_code, 200)
+        self.review_report.refresh_from_db()
+        self.review.refresh_from_db()
+        self.assertEqual(self.review_report.status, ContentReport.Status.REJECTED)
+        self.assertTrue(self.review.is_visible)
+        self.assertFalse(self.review.is_flagged)
+        # No email sent on reject
+        send_mail_mock.assert_not_called()
+
+    def test_reject_comment_report_restores_comment(self):
+        self.comment.is_flagged = True
+        self.comment.save(update_fields=["is_flagged", "updated_at"])
+        self.client.force_login(self.admin)
+        res = self.client.post(
+            reverse("admin_moderation_action", args=[self.comment_report.id]),
+            data=json.dumps({"action": "reject"}),
+            content_type="application/json",
+        )
+        self.assertEqual(res.status_code, 200)
+        self.comment.refresh_from_db()
+        self.assertTrue(self.comment.is_visible)
+        self.assertFalse(self.comment.is_flagged)
+
+    def test_reject_does_not_unhide_when_another_confirmed_report_exists(self):
+        """Regression: rejecting a pending report must not resurrect content
+        that was already hidden by a separately confirmed report."""
+        # First report is confirmed → review hidden
+        confirmed_report = ContentReport.objects.create(
+            review=self.review,
+            reporter=self.reporter,
+            reason="really bad",
+            status=ContentReport.Status.CONFIRMED,
+            reviewed_by=self.admin,
+            reviewed_at=timezone.now(),
+        )
+        self.review.is_visible = False
+        self.review.is_flagged = True
+        self.review.save(update_fields=["is_visible", "is_flagged", "updated_at"])
+
+        # Second pending report on the same review gets rejected
+        self.client.force_login(self.admin)
+        res = self.client.post(
+            reverse("admin_moderation_action", args=[self.review_report.id]),
+            data=json.dumps({"action": "reject"}),
+            content_type="application/json",
+        )
+        self.assertEqual(res.status_code, 200)
+        self.review.refresh_from_db()
+        # Confirmed sibling still wants the content hidden
+        self.assertFalse(self.review.is_visible)
+        self.assertTrue(self.review.is_flagged)
+        # Sanity-check the rejected report did update its own status
+        self.review_report.refresh_from_db()
+        self.assertEqual(self.review_report.status, ContentReport.Status.REJECTED)
+        # Confirmed report unchanged
+        confirmed_report.refresh_from_db()
+        self.assertEqual(confirmed_report.status, ContentReport.Status.CONFIRMED)
+
+    def test_reject_keeps_flag_when_other_pending_report_exists(self):
+        ContentReport.objects.create(
+            review=self.review,
+            reporter=self.reporter,
+            reason="another open complaint",
+        )
+        self.review.is_flagged = True
+        self.review.save(update_fields=["is_flagged", "updated_at"])
+
+        self.client.force_login(self.admin)
+        res = self.client.post(
+            reverse("admin_moderation_action", args=[self.review_report.id]),
+            data=json.dumps({"action": "reject"}),
+            content_type="application/json",
+        )
+        self.assertEqual(res.status_code, 200)
+        self.review.refresh_from_db()
+        self.assertTrue(self.review.is_visible)
+        # Other pending report still implies the content is flagged for review
+        self.assertTrue(self.review.is_flagged)
 
 
 class StrictPreferenceFilterTest(TestCase):

--- a/backend/venues/tests.py
+++ b/backend/venues/tests.py
@@ -9,7 +9,7 @@ from unittest.mock import MagicMock, patch
 from django.contrib.auth import get_user_model
 from django.core.management import call_command
 from django.db import IntegrityError
-from django.test import TestCase, override_settings
+from django.test import TestCase, override_settings, Client
 from django.urls import reverse
 
 from accounts.models import (
@@ -28,6 +28,7 @@ from venues.management.commands.ingest_csv import (
     map_price_range,
 )
 from venues.models import (
+    ContentReport,
     Inspection,
     Review,
     ReviewComment,
@@ -1515,6 +1516,79 @@ class ReviewCommentTests(TestCase):
         comments = list(self.review.comments.all())
         self.assertEqual(comments[0].content, "First")
         self.assertEqual(comments[1].content, "Second")
+
+
+class ModerationWorkflowTests(TestCase):
+    def setUp(self):
+        self.client = Client()
+        self.admin = User.objects.create_user(
+            email="admin@nyu.edu",
+            password="pass",
+            role="admin",
+            is_staff=True,
+        )
+        self.reporter = User.objects.create_user(email="reporter@nyu.edu", password="pass")
+        self.author = User.objects.create_user(email="author@nyu.edu", password="pass")
+        self.venue = Venue.objects.create(name="Queue Venue")
+        self.review = Review.objects.create(
+            venue=self.venue,
+            user=self.author,
+            rating=2,
+            title="Bad",
+            content="Offensive text",
+            visit_date=datetime.date(2025, 1, 1),
+        )
+
+    def test_report_review_creates_pending_report(self):
+        self.client.force_login(self.reporter)
+        res = self.client.post(
+            reverse("report_review", args=[self.review.id]),
+            data=json.dumps({"reason": "Harassment"}),
+            content_type="application/json",
+        )
+        self.assertEqual(res.status_code, 201)
+        self.review.refresh_from_db()
+        self.assertTrue(self.review.is_flagged)
+        report = ContentReport.objects.get(review=self.review)
+        self.assertEqual(report.status, ContentReport.Status.PENDING)
+        self.assertEqual(report.reporter_id, self.reporter.id)
+
+    def test_admin_confirm_hides_content_and_records_audit(self):
+        report = ContentReport.objects.create(
+            review=self.review,
+            reporter=self.reporter,
+            reason="Abusive language",
+        )
+        self.client.force_login(self.admin)
+        with patch("venues.views.send_mail") as send_mail_mock:
+            res = self.client.post(
+                reverse("admin_moderation_action", args=[report.id]),
+                data=json.dumps({"action": "confirm"}),
+                content_type="application/json",
+            )
+        self.assertEqual(res.status_code, 200)
+        report.refresh_from_db()
+        self.review.refresh_from_db()
+        self.assertEqual(report.status, ContentReport.Status.CONFIRMED)
+        self.assertEqual(report.reviewed_by_id, self.admin.id)
+        self.assertIsNotNone(report.reviewed_at)
+        self.assertFalse(self.review.is_visible)
+        send_mail_mock.assert_called_once()
+
+    def test_admin_queue_includes_report_reason_and_reporter(self):
+        ContentReport.objects.create(
+            review=self.review,
+            reporter=self.reporter,
+            reason="Spam",
+        )
+        self.client.force_login(self.admin)
+        res = self.client.get(reverse("admin_moderation_queue"))
+        self.assertEqual(res.status_code, 200)
+        payload = res.json()
+        self.assertEqual(payload["totalCount"], 1)
+        first = payload["reports"][0]
+        self.assertEqual(first["reason"], "Spam")
+        self.assertEqual(first["reporter"]["email"], "reporter@nyu.edu")
 
 
 class StrictPreferenceFilterTest(TestCase):

--- a/backend/venues/urls.py
+++ b/backend/venues/urls.py
@@ -20,6 +20,12 @@ urlpatterns = [
         views.api_venue_discount_detail,
         name="venue_discount_detail",
     ),
+    path("<int:venue_id>/reviews/", views.api_venue_reviews, name="venue_reviews"),
+    path(
+        "<int:venue_id>/reviews/<int:review_id>/comments/",
+        views.api_venue_review_comment,
+        name="venue_review_comment",
+    ),
     path(
         "reviews/<int:review_id>/report/", views.api_report_review, name="report_review"
     ),

--- a/backend/venues/urls.py
+++ b/backend/venues/urls.py
@@ -20,7 +20,9 @@ urlpatterns = [
         views.api_venue_discount_detail,
         name="venue_discount_detail",
     ),
-    path("reviews/<int:review_id>/report/", views.api_report_review, name="report_review"),
+    path(
+        "reviews/<int:review_id>/report/", views.api_report_review, name="report_review"
+    ),
     path(
         "review-comments/<int:comment_id>/report/",
         views.api_report_review_comment,

--- a/backend/venues/urls.py
+++ b/backend/venues/urls.py
@@ -20,7 +20,23 @@ urlpatterns = [
         views.api_venue_discount_detail,
         name="venue_discount_detail",
     ),
+    path("reviews/<int:review_id>/report/", views.api_report_review, name="report_review"),
+    path(
+        "review-comments/<int:comment_id>/report/",
+        views.api_report_review_comment,
+        name="report_review_comment",
+    ),
     # Admin venue verification
+    path(
+        "admin/moderation/",
+        views.api_admin_moderation_queue,
+        name="admin_moderation_queue",
+    ),
+    path(
+        "admin/moderation/<int:report_id>/",
+        views.api_admin_moderation_action,
+        name="admin_moderation_action",
+    ),
     path("admin/claims/", views.api_admin_venue_claims, name="admin_venue_claims"),
     path(
         "admin/claims/<int:claim_id>/",

--- a/backend/venues/views.py
+++ b/backend/venues/views.py
@@ -6,13 +6,46 @@ from django.http import JsonResponse
 from django.db import transaction
 from django.db.models import F, prefetch_related_objects
 from django.utils import timezone
+from django.core.mail import send_mail
+from django.conf import settings
 
-from .models import Venue, StudentDiscount, VenueClaim
+from .models import (
+    Venue,
+    StudentDiscount,
+    VenueClaim,
+    Review,
+    ReviewComment,
+    ContentReport,
+)
 from .filters import filter_venues_by_preferences
 from .google_places import bulk_prefetch_photos
 from accounts.models import VenueManagerProfile, CuisineType, DietaryTag, FoodTypeTag
 
 logger = logging.getLogger(__name__)
+
+
+def _safe_display_name(user):
+    full_name = f"{user.first_name} {user.last_name}".strip()
+    return full_name or user.email
+
+
+def _notify_content_removed(user, venue_name, content_type):
+    """Best-effort email notification when admin removes reported content."""
+    subject = "Your MealSwipe content was removed"
+    message = (
+        f"Your {content_type} for {venue_name} was removed by an administrator "
+        "after moderation review."
+    )
+    try:
+        send_mail(
+            subject,
+            message,
+            settings.DEFAULT_FROM_EMAIL,
+            [user.email],
+            fail_silently=True,
+        )
+    except Exception:
+        logger.warning("Failed to send moderation email to %s", user.email, exc_info=True)
 
 
 def _require_venue_manager(request):
@@ -411,6 +444,217 @@ def api_venue_discount_detail(request, venue_id, discount_id):
         return JsonResponse({"success": True})
 
     return JsonResponse({"error": "Method not allowed"}, status=405)
+
+
+# ---------------------------------------------------------------------------
+# Content Moderation API
+# ---------------------------------------------------------------------------
+
+
+def _content_report_to_json(report):
+    if report.review_id:
+        target = report.review
+        content_type = "review"
+        content_body = target.content
+        venue_name = target.venue.name
+        author = target.user
+    else:
+        target = report.comment
+        content_type = "comment"
+        content_body = target.content
+        venue_name = target.review.venue.name
+        author = target.user
+
+    reviewer = report.reviewed_by
+    return {
+        "id": report.id,
+        "status": report.status,
+        "reason": report.reason,
+        "createdAt": report.created_at.isoformat(),
+        "reviewedAt": report.reviewed_at.isoformat() if report.reviewed_at else None,
+        "contentType": content_type,
+        "content": {
+            "id": target.id,
+            "title": getattr(target, "title", ""),
+            "body": content_body,
+            "venueName": venue_name,
+            "authorEmail": author.email,
+            "authorName": _safe_display_name(author),
+        },
+        "reporter": {
+            "id": report.reporter_id,
+            "email": report.reporter.email,
+            "name": _safe_display_name(report.reporter),
+        },
+        "reviewer": (
+            {
+                "id": reviewer.id,
+                "email": reviewer.email,
+                "name": _safe_display_name(reviewer),
+            }
+            if reviewer
+            else None
+        ),
+    }
+
+
+def api_report_review(request, review_id):
+    """POST /api/venues/reviews/<review_id>/report/"""
+    if request.method != "POST":
+        return JsonResponse({"error": "Method not allowed"}, status=405)
+    if not request.user.is_authenticated:
+        return JsonResponse({"error": "Authentication required"}, status=401)
+    try:
+        review = Review.objects.select_related("user", "venue").get(pk=review_id)
+    except Review.DoesNotExist:
+        return JsonResponse({"error": "Review not found"}, status=404)
+
+    try:
+        data = json.loads(request.body or "{}")
+    except (json.JSONDecodeError, TypeError):
+        return JsonResponse({"error": "Invalid JSON"}, status=400)
+    reason = (data.get("reason") or "").strip()
+    if not reason:
+        return JsonResponse({"error": "Report reason is required"}, status=400)
+
+    report = ContentReport.objects.create(
+        review=review,
+        reporter=request.user,
+        reason=reason,
+    )
+    if not review.is_flagged:
+        review.is_flagged = True
+        review.save(update_fields=["is_flagged", "updated_at"])
+    return JsonResponse({"success": True, "report": _content_report_to_json(report)}, status=201)
+
+
+def api_report_review_comment(request, comment_id):
+    """POST /api/venues/review-comments/<comment_id>/report/"""
+    if request.method != "POST":
+        return JsonResponse({"error": "Method not allowed"}, status=405)
+    if not request.user.is_authenticated:
+        return JsonResponse({"error": "Authentication required"}, status=401)
+    try:
+        comment = ReviewComment.objects.select_related("user", "review__venue").get(pk=comment_id)
+    except ReviewComment.DoesNotExist:
+        return JsonResponse({"error": "Comment not found"}, status=404)
+
+    try:
+        data = json.loads(request.body or "{}")
+    except (json.JSONDecodeError, TypeError):
+        return JsonResponse({"error": "Invalid JSON"}, status=400)
+    reason = (data.get("reason") or "").strip()
+    if not reason:
+        return JsonResponse({"error": "Report reason is required"}, status=400)
+
+    report = ContentReport.objects.create(
+        comment=comment,
+        reporter=request.user,
+        reason=reason,
+    )
+    if not comment.is_flagged:
+        comment.is_flagged = True
+        comment.save(update_fields=["is_flagged", "updated_at"])
+    return JsonResponse({"success": True, "report": _content_report_to_json(report)}, status=201)
+
+
+def api_admin_moderation_queue(request):
+    """GET /api/venues/admin/moderation/?status=pending&page=1"""
+    if request.method != "GET":
+        return JsonResponse({"error": "Method not allowed"}, status=405)
+    err = _require_admin(request)
+    if err:
+        return err
+
+    status_filter = (request.GET.get("status") or "pending").strip()
+    page = int(request.GET.get("page", 1))
+    per_page = 20
+
+    reports_qs = ContentReport.objects.select_related(
+        "reporter",
+        "reviewed_by",
+        "review__user",
+        "review__venue",
+        "comment__user",
+        "comment__review__venue",
+    ).order_by("-created_at")
+
+    if status_filter in dict(ContentReport.Status.choices):
+        reports_qs = reports_qs.filter(status=status_filter)
+
+    total = reports_qs.count()
+    total_pages = max(1, math.ceil(total / per_page))
+    page = min(page, total_pages)
+    offset = (page - 1) * per_page
+    reports_page = reports_qs[offset : offset + per_page]
+
+    return JsonResponse(
+        {
+            "success": True,
+            "reports": [_content_report_to_json(report) for report in reports_page],
+            "page": page,
+            "totalPages": total_pages,
+            "totalCount": total,
+        }
+    )
+
+
+def api_admin_moderation_action(request, report_id):
+    """POST /api/venues/admin/moderation/<id>/ with action=confirm|reject."""
+    if request.method != "POST":
+        return JsonResponse({"error": "Method not allowed"}, status=405)
+    err = _require_admin(request)
+    if err:
+        return err
+
+    try:
+        report = ContentReport.objects.select_related(
+            "review__user",
+            "review__venue",
+            "comment__user",
+            "comment__review__venue",
+            "reporter",
+        ).get(pk=report_id)
+    except ContentReport.DoesNotExist:
+        return JsonResponse({"error": "Report not found"}, status=404)
+
+    try:
+        data = json.loads(request.body or "{}")
+    except (json.JSONDecodeError, TypeError):
+        return JsonResponse({"error": "Invalid JSON"}, status=400)
+    action = (data.get("action") or "").strip().lower()
+    if action not in ("confirm", "reject"):
+        return JsonResponse({"error": "action must be 'confirm' or 'reject'"}, status=400)
+
+    with transaction.atomic():
+        report.reviewed_by = request.user
+        report.reviewed_at = timezone.now()
+        if action == "confirm":
+            report.status = ContentReport.Status.CONFIRMED
+            if report.review_id:
+                report.review.is_visible = False
+                report.review.is_flagged = True
+                report.review.save(update_fields=["is_visible", "is_flagged", "updated_at"])
+                _notify_content_removed(report.review.user, report.review.venue.name, "review")
+            else:
+                report.comment.is_visible = False
+                report.comment.is_flagged = True
+                report.comment.save(update_fields=["is_visible", "is_flagged", "updated_at"])
+                _notify_content_removed(report.comment.user, report.comment.review.venue.name, "comment")
+        else:
+            report.status = ContentReport.Status.REJECTED
+            if report.review_id:
+                report.review.is_visible = True
+                report.review.is_flagged = False
+                report.review.save(update_fields=["is_visible", "is_flagged", "updated_at"])
+            else:
+                report.comment.is_visible = True
+                report.comment.is_flagged = False
+                report.comment.save(update_fields=["is_visible", "is_flagged", "updated_at"])
+
+        report.save(update_fields=["status", "reviewed_by", "reviewed_at", "updated_at"])
+
+    return JsonResponse({"success": True, "report": _content_report_to_json(report)})
 
 
 # ---------------------------------------------------------------------------

--- a/backend/venues/views.py
+++ b/backend/venues/views.py
@@ -45,7 +45,9 @@ def _notify_content_removed(user, venue_name, content_type):
             fail_silently=True,
         )
     except Exception:
-        logger.warning("Failed to send moderation email to %s", user.email, exc_info=True)
+        logger.warning(
+            "Failed to send moderation email to %s", user.email, exc_info=True
+        )
 
 
 def _require_venue_manager(request):
@@ -525,7 +527,9 @@ def api_report_review(request, review_id):
     if not review.is_flagged:
         review.is_flagged = True
         review.save(update_fields=["is_flagged", "updated_at"])
-    return JsonResponse({"success": True, "report": _content_report_to_json(report)}, status=201)
+    return JsonResponse(
+        {"success": True, "report": _content_report_to_json(report)}, status=201
+    )
 
 
 def api_report_review_comment(request, comment_id):
@@ -535,7 +539,9 @@ def api_report_review_comment(request, comment_id):
     if not request.user.is_authenticated:
         return JsonResponse({"error": "Authentication required"}, status=401)
     try:
-        comment = ReviewComment.objects.select_related("user", "review__venue").get(pk=comment_id)
+        comment = ReviewComment.objects.select_related("user", "review__venue").get(
+            pk=comment_id
+        )
     except ReviewComment.DoesNotExist:
         return JsonResponse({"error": "Comment not found"}, status=404)
 
@@ -555,7 +561,9 @@ def api_report_review_comment(request, comment_id):
     if not comment.is_flagged:
         comment.is_flagged = True
         comment.save(update_fields=["is_flagged", "updated_at"])
-    return JsonResponse({"success": True, "report": _content_report_to_json(report)}, status=201)
+    return JsonResponse(
+        {"success": True, "report": _content_report_to_json(report)}, status=201
+    )
 
 
 def api_admin_moderation_queue(request):
@@ -624,7 +632,9 @@ def api_admin_moderation_action(request, report_id):
         return JsonResponse({"error": "Invalid JSON"}, status=400)
     action = (data.get("action") or "").strip().lower()
     if action not in ("confirm", "reject"):
-        return JsonResponse({"error": "action must be 'confirm' or 'reject'"}, status=400)
+        return JsonResponse(
+            {"error": "action must be 'confirm' or 'reject'"}, status=400
+        )
 
     with transaction.atomic():
         report.reviewed_by = request.user
@@ -634,25 +644,39 @@ def api_admin_moderation_action(request, report_id):
             if report.review_id:
                 report.review.is_visible = False
                 report.review.is_flagged = True
-                report.review.save(update_fields=["is_visible", "is_flagged", "updated_at"])
-                _notify_content_removed(report.review.user, report.review.venue.name, "review")
+                report.review.save(
+                    update_fields=["is_visible", "is_flagged", "updated_at"]
+                )
+                _notify_content_removed(
+                    report.review.user, report.review.venue.name, "review"
+                )
             else:
                 report.comment.is_visible = False
                 report.comment.is_flagged = True
-                report.comment.save(update_fields=["is_visible", "is_flagged", "updated_at"])
-                _notify_content_removed(report.comment.user, report.comment.review.venue.name, "comment")
+                report.comment.save(
+                    update_fields=["is_visible", "is_flagged", "updated_at"]
+                )
+                _notify_content_removed(
+                    report.comment.user, report.comment.review.venue.name, "comment"
+                )
         else:
             report.status = ContentReport.Status.REJECTED
             if report.review_id:
                 report.review.is_visible = True
                 report.review.is_flagged = False
-                report.review.save(update_fields=["is_visible", "is_flagged", "updated_at"])
+                report.review.save(
+                    update_fields=["is_visible", "is_flagged", "updated_at"]
+                )
             else:
                 report.comment.is_visible = True
                 report.comment.is_flagged = False
-                report.comment.save(update_fields=["is_visible", "is_flagged", "updated_at"])
+                report.comment.save(
+                    update_fields=["is_visible", "is_flagged", "updated_at"]
+                )
 
-        report.save(update_fields=["status", "reviewed_by", "reviewed_at", "updated_at"])
+        report.save(
+            update_fields=["status", "reviewed_by", "reviewed_at", "updated_at"]
+        )
 
     return JsonResponse({"success": True, "report": _content_report_to_json(report)})
 

--- a/backend/venues/views.py
+++ b/backend/venues/views.py
@@ -1,10 +1,11 @@
 import json
 import logging
 import math
+from datetime import date
 
 from django.http import JsonResponse
 from django.db import transaction
-from django.db.models import F, prefetch_related_objects
+from django.db.models import F, Prefetch, prefetch_related_objects
 from django.utils import timezone
 from django.core.mail import send_mail
 from django.conf import settings
@@ -132,6 +133,64 @@ def _discount_to_json(discount):
         ),
         "createdAt": discount.created_at.isoformat(),
         "updatedAt": discount.updated_at.isoformat(),
+    }
+
+
+def _venue_review_summary(venue):
+    return {
+        "id": venue.id,
+        "name": venue.name,
+        "streetAddress": venue.street_address,
+        "borough": venue.borough,
+        "priceRange": venue.price_range,
+        "cuisineType": venue.cuisine_type.name if venue.cuisine_type else "",
+    }
+
+
+def _review_comment_to_json(comment):
+    author = comment.user
+    return {
+        "id": comment.id,
+        "content": comment.content,
+        "isManagerResponse": comment.is_manager_response,
+        "isFlagged": comment.is_flagged,
+        "isVisible": comment.is_visible,
+        "createdAt": comment.created_at.isoformat(),
+        "updatedAt": comment.updated_at.isoformat(),
+        "author": {
+            "id": author.id,
+            "email": author.email,
+            "name": _safe_display_name(author),
+            "role": author.role,
+        },
+    }
+
+
+def _review_to_json(review, include_hidden=False):
+    comments = review.comments.all()
+    if not include_hidden:
+        comments = comments.filter(is_visible=True)
+    comments = comments.order_by("created_at")
+
+    return {
+        "id": review.id,
+        "venueId": review.venue_id,
+        "rating": review.rating,
+        "title": review.title,
+        "content": review.content,
+        "visitDate": review.visit_date.isoformat(),
+        "additionalPhotos": list(review.additional_photos or []),
+        "isFlagged": review.is_flagged,
+        "isVisible": review.is_visible,
+        "createdAt": review.created_at.isoformat(),
+        "updatedAt": review.updated_at.isoformat(),
+        "author": {
+            "id": review.user.id,
+            "email": review.user.email,
+            "name": _safe_display_name(review.user),
+            "role": review.user.role,
+        },
+        "comments": [_review_comment_to_json(comment) for comment in comments],
     }
 
 
@@ -446,6 +505,170 @@ def api_venue_discount_detail(request, venue_id, discount_id):
         return JsonResponse({"success": True})
 
     return JsonResponse({"error": "Method not allowed"}, status=405)
+
+
+def api_venue_reviews(request, venue_id):
+    """
+    GET  /api/venues/<id>/reviews/  — list visible reviews, or all reviews for the
+                                       venue manager who owns the venue
+    POST /api/venues/<id>/reviews/  — create a new review
+    """
+    try:
+        venue = (
+            Venue.objects.select_related(
+                "cuisine_type", "managed_by", "managed_by__user"
+            )
+            .prefetch_related(
+                Prefetch(
+                    "reviews",
+                    queryset=Review.objects.select_related("user").prefetch_related(
+                        Prefetch(
+                            "comments",
+                            queryset=ReviewComment.objects.select_related(
+                                "user"
+                            ).order_by("created_at"),
+                        )
+                    ),
+                )
+            )
+            .get(pk=venue_id, is_active=True)
+        )
+    except Venue.DoesNotExist:
+        return JsonResponse({"error": "Venue not found"}, status=404)
+
+    is_owner_manager = (
+        request.user.is_authenticated
+        and request.user.role == "venue_manager"
+        and venue.managed_by is not None
+        and venue.managed_by.user_id == request.user.id
+    )
+
+    if request.method == "GET":
+        reviews = venue.reviews.all().order_by("-created_at")
+        if not is_owner_manager:
+            reviews = reviews.filter(is_visible=True)
+        return JsonResponse(
+            {
+                "success": True,
+                "venue": _venue_review_summary(venue),
+                "canReply": is_owner_manager,
+                "reviews": [
+                    _review_to_json(review, include_hidden=is_owner_manager)
+                    for review in reviews
+                ],
+            }
+        )
+
+    if request.method == "POST":
+        if not request.user.is_authenticated:
+            return JsonResponse({"error": "Authentication required"}, status=401)
+        if request.user.role != "student":
+            return JsonResponse({"error": "Student access required"}, status=403)
+
+        try:
+            data = json.loads(request.body or "{}")
+        except (json.JSONDecodeError, TypeError):
+            return JsonResponse({"error": "Invalid JSON"}, status=400)
+
+        try:
+            rating = int(data.get("rating"))
+        except (TypeError, ValueError):
+            return JsonResponse({"error": "Rating is required"}, status=400)
+        if rating < 1 or rating > 5:
+            return JsonResponse({"error": "Rating must be between 1 and 5"}, status=400)
+
+        visit_date_raw = (data.get("visitDate") or "").strip()
+        try:
+            visit_date = date.fromisoformat(visit_date_raw)
+        except ValueError:
+            return JsonResponse({"error": "Valid visitDate is required"}, status=400)
+
+        additional_photos = data.get("additionalPhotos") or []
+        if not isinstance(additional_photos, list):
+            return JsonResponse(
+                {"error": "additionalPhotos must be a list"}, status=400
+            )
+        clean_photos = [
+            photo.strip()
+            for photo in additional_photos
+            if isinstance(photo, str) and photo.strip()
+        ]
+        if len(clean_photos) > 5:
+            return JsonResponse(
+                {"error": "At most 5 additional photos are allowed"}, status=400
+            )
+
+        review = Review.objects.create(
+            venue=venue,
+            user=request.user,
+            rating=rating,
+            title=(data.get("title") or "").strip(),
+            content=(data.get("content") or "").strip(),
+            visit_date=visit_date,
+            additional_photos=clean_photos,
+        )
+        return JsonResponse(
+            {
+                "success": True,
+                "review": _review_to_json(review, include_hidden=True),
+            },
+            status=201,
+        )
+
+    return JsonResponse({"error": "Method not allowed"}, status=405)
+
+
+def api_venue_review_comment(request, venue_id, review_id):
+    """
+    POST /api/venues/<venue_id>/reviews/<review_id>/comments/
+    Venue managers can add owner responses to reviews they own.
+    """
+    if request.method != "POST":
+        return JsonResponse({"error": "Method not allowed"}, status=405)
+
+    manager, err = _require_venue_manager(request)
+    if err:
+        return err
+
+    try:
+        venue = Venue.objects.select_related("managed_by", "managed_by__user").get(
+            pk=venue_id, is_active=True
+        )
+    except Venue.DoesNotExist:
+        return JsonResponse({"error": "Venue not found"}, status=404)
+
+    if venue.managed_by_id != manager.id:
+        return JsonResponse({"error": "You do not manage this venue"}, status=403)
+
+    try:
+        review = Review.objects.select_related("venue", "user").get(
+            pk=review_id, venue=venue
+        )
+    except Review.DoesNotExist:
+        return JsonResponse({"error": "Review not found"}, status=404)
+
+    try:
+        data = json.loads(request.body or "{}")
+    except (json.JSONDecodeError, TypeError):
+        return JsonResponse({"error": "Invalid JSON"}, status=400)
+
+    content = (data.get("content") or "").strip()
+    if not content:
+        return JsonResponse({"error": "Comment content is required"}, status=400)
+
+    comment = ReviewComment.objects.create(
+        review=review,
+        user=request.user,
+        content=content,
+        is_manager_response=True,
+    )
+    return JsonResponse(
+        {
+            "success": True,
+            "comment": _review_comment_to_json(comment),
+        },
+        status=201,
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/backend/venues/views.py
+++ b/backend/venues/views.py
@@ -884,18 +884,29 @@ def api_admin_moderation_action(request, report_id):
                 )
         else:
             report.status = ContentReport.Status.REJECTED
-            if report.review_id:
-                report.review.is_visible = True
-                report.review.is_flagged = False
-                report.review.save(
-                    update_fields=["is_visible", "is_flagged", "updated_at"]
-                )
-            else:
-                report.comment.is_visible = True
-                report.comment.is_flagged = False
-                report.comment.save(
-                    update_fields=["is_visible", "is_flagged", "updated_at"]
-                )
+            target = report.review if report.review_id else report.comment
+            sibling_filter = (
+                {"review_id": report.review_id}
+                if report.review_id
+                else {"comment_id": report.comment_id}
+            )
+            siblings = ContentReport.objects.filter(**sibling_filter).exclude(
+                pk=report.pk
+            )
+            # Only restore visibility if no other report on this content is still confirmed.
+            other_confirmed = siblings.filter(
+                status=ContentReport.Status.CONFIRMED
+            ).exists()
+            other_open = siblings.filter(status=ContentReport.Status.PENDING).exists()
+
+            update_fields = ["updated_at"]
+            if not other_confirmed:
+                target.is_visible = True
+                update_fields.append("is_visible")
+            if not other_confirmed and not other_open:
+                target.is_flagged = False
+                update_fields.append("is_flagged")
+            target.save(update_fields=update_fields)
 
         report.save(
             update_fields=["status", "reviewed_by", "reviewed_at", "updated_at"]

--- a/frontend/src/app/components/__tests__/route-guards.test.tsx
+++ b/frontend/src/app/components/__tests__/route-guards.test.tsx
@@ -38,6 +38,7 @@ describe('Route Guards', () => {
     mockUseApp.mockReset();
     mockUseAdmin.mockReset();
     mockUseVenue.mockReset();
+    mockUseApp.mockReturnValue({ currentUser: null });
   });
 
   it('redirects admin away from student route', () => {
@@ -82,16 +83,20 @@ describe('Route Guards', () => {
     expect(screen.getByTestId('location').textContent).toBe('/venue/dashboard');
   });
 
-  it('rejects non-admin user in admin route guard', () => {
+  it('redirects student from admin route to home', () => {
+    mockUseApp.mockReturnValue({
+      currentUser: { id: '3', role: 'student' },
+    });
     mockUseAdmin.mockReturnValue({
       authLoading: false,
-      currentAdmin: { id: '3', role: 'student' },
+      currentAdmin: null,
     });
 
     render(
       <MemoryRouter initialEntries={['/admin/dashboard']}>
         <Routes>
-          <Route path="/" element={<LocationEcho />} />
+          <Route path="/home" element={<LocationEcho />} />
+          <Route path="/venue/dashboard" element={<LocationEcho />} />
           <Route path="/admin/login" element={<LocationEcho />} />
           <Route element={<AdminProtectedRoute />}>
             <Route path="/admin/dashboard" element={<Outlet />} />
@@ -100,19 +105,48 @@ describe('Route Guards', () => {
       </MemoryRouter>
     );
 
-    expect(screen.getByTestId('location').textContent).toBe('/');
+    expect(screen.getByTestId('location').textContent).toBe('/home');
   });
 
-  it('rejects non-venue role in venue route guard', () => {
+  it('redirects venue manager from admin route to venue dashboard', () => {
+    mockUseApp.mockReturnValue({
+      currentUser: { id: '4', role: 'venue_manager' },
+    });
+    mockUseAdmin.mockReturnValue({
+      authLoading: false,
+      currentAdmin: null,
+    });
+
+    render(
+      <MemoryRouter initialEntries={['/admin/dashboard']}>
+        <Routes>
+          <Route path="/home" element={<LocationEcho />} />
+          <Route path="/venue/dashboard" element={<LocationEcho />} />
+          <Route path="/admin/login" element={<LocationEcho />} />
+          <Route element={<AdminProtectedRoute />}>
+            <Route path="/admin/dashboard" element={<Outlet />} />
+          </Route>
+        </Routes>
+      </MemoryRouter>
+    );
+
+    expect(screen.getByTestId('location').textContent).toBe('/venue/dashboard');
+  });
+
+  it('redirects admin from venue route to admin dashboard', () => {
+    mockUseApp.mockReturnValue({
+      currentUser: { id: '5', role: 'admin' },
+    });
     mockUseVenue.mockReturnValue({
       authLoading: false,
-      currentManager: { id: '4', role: 'student' },
+      currentManager: null,
     });
 
     render(
       <MemoryRouter initialEntries={['/venue/dashboard']}>
         <Routes>
-          <Route path="/" element={<LocationEcho />} />
+          <Route path="/home" element={<LocationEcho />} />
+          <Route path="/admin/dashboard" element={<LocationEcho />} />
           <Route path="/venue/login" element={<LocationEcho />} />
           <Route element={<VenueProtectedRoute />}>
             <Route path="/venue/dashboard" element={<Outlet />} />
@@ -121,6 +155,6 @@ describe('Route Guards', () => {
       </MemoryRouter>
     );
 
-    expect(screen.getByTestId('location').textContent).toBe('/');
+    expect(screen.getByTestId('location').textContent).toBe('/admin/dashboard');
   });
 });

--- a/frontend/src/app/components/__tests__/route-guards.test.tsx
+++ b/frontend/src/app/components/__tests__/route-guards.test.tsx
@@ -1,0 +1,126 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter, Navigate, Outlet, Route, Routes, useLocation } from 'react-router';
+import { ProtectedRoute } from '@/app/components/protected-route';
+import { AdminProtectedRoute } from '@/app/components/admin-protected-route';
+import { VenueProtectedRoute } from '@/app/components/venue-protected-route';
+
+const mockUseApp = vi.fn();
+const mockUseAdmin = vi.fn();
+const mockUseVenue = vi.fn();
+
+vi.mock('@/app/contexts/app-context', () => ({
+  useApp: () => mockUseApp(),
+}));
+vi.mock('@/app/contexts/admin-context', () => ({
+  useAdmin: () => mockUseAdmin(),
+}));
+vi.mock('@/app/contexts/venue-context', () => ({
+  useVenue: () => mockUseVenue(),
+}));
+vi.mock('@/app/components/top-nav', () => ({
+  TopNav: () => <div>TopNav</div>,
+}));
+vi.mock('@/app/components/admin-top-nav', () => ({
+  AdminTopNav: () => <div>AdminTopNav</div>,
+}));
+vi.mock('@/app/components/venue-top-nav', () => ({
+  VenueTopNav: () => <div>VenueTopNav</div>,
+}));
+
+function LocationEcho() {
+  const location = useLocation();
+  return <div data-testid="location">{location.pathname}</div>;
+}
+
+describe('Route Guards', () => {
+  beforeEach(() => {
+    mockUseApp.mockReset();
+    mockUseAdmin.mockReset();
+    mockUseVenue.mockReset();
+  });
+
+  it('redirects admin away from student route', () => {
+    mockUseApp.mockReturnValue({
+      currentUser: { id: '1', role: 'admin' },
+    });
+
+    render(
+      <MemoryRouter initialEntries={['/home']}>
+        <Routes>
+          <Route path="/" element={<LocationEcho />} />
+          <Route path="/admin/dashboard" element={<LocationEcho />} />
+          <Route element={<ProtectedRoute />}>
+            <Route path="/home" element={<Outlet />} />
+          </Route>
+          <Route path="*" element={<Navigate to="/" replace />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    expect(screen.getByTestId('location').textContent).toBe('/admin/dashboard');
+  });
+
+  it('redirects venue manager away from student route', () => {
+    mockUseApp.mockReturnValue({
+      currentUser: { id: '2', role: 'venue_manager' },
+    });
+
+    render(
+      <MemoryRouter initialEntries={['/home']}>
+        <Routes>
+          <Route path="/" element={<LocationEcho />} />
+          <Route path="/venue/dashboard" element={<LocationEcho />} />
+          <Route element={<ProtectedRoute />}>
+            <Route path="/home" element={<Outlet />} />
+          </Route>
+          <Route path="*" element={<Navigate to="/" replace />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    expect(screen.getByTestId('location').textContent).toBe('/venue/dashboard');
+  });
+
+  it('rejects non-admin user in admin route guard', () => {
+    mockUseAdmin.mockReturnValue({
+      authLoading: false,
+      currentAdmin: { id: '3', role: 'student' },
+    });
+
+    render(
+      <MemoryRouter initialEntries={['/admin/dashboard']}>
+        <Routes>
+          <Route path="/" element={<LocationEcho />} />
+          <Route path="/admin/login" element={<LocationEcho />} />
+          <Route element={<AdminProtectedRoute />}>
+            <Route path="/admin/dashboard" element={<Outlet />} />
+          </Route>
+        </Routes>
+      </MemoryRouter>
+    );
+
+    expect(screen.getByTestId('location').textContent).toBe('/');
+  });
+
+  it('rejects non-venue role in venue route guard', () => {
+    mockUseVenue.mockReturnValue({
+      authLoading: false,
+      currentManager: { id: '4', role: 'student' },
+    });
+
+    render(
+      <MemoryRouter initialEntries={['/venue/dashboard']}>
+        <Routes>
+          <Route path="/" element={<LocationEcho />} />
+          <Route path="/venue/login" element={<LocationEcho />} />
+          <Route element={<VenueProtectedRoute />}>
+            <Route path="/venue/dashboard" element={<Outlet />} />
+          </Route>
+        </Routes>
+      </MemoryRouter>
+    );
+
+    expect(screen.getByTestId('location').textContent).toBe('/');
+  });
+});

--- a/frontend/src/app/components/admin-protected-route.tsx
+++ b/frontend/src/app/components/admin-protected-route.tsx
@@ -25,9 +25,6 @@ export function AdminProtectedRoute() {
     }
     return <Navigate to="/admin/login" state={{ from: location }} replace />;
   }
-  if (currentAdmin.role !== 'admin') {
-    return <Navigate to="/home" state={{ from: location }} replace />;
-  }
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-purple-50 via-pink-50 to-orange-50 flex flex-col">

--- a/frontend/src/app/components/admin-protected-route.tsx
+++ b/frontend/src/app/components/admin-protected-route.tsx
@@ -17,6 +17,9 @@ export function AdminProtectedRoute() {
   if (!currentAdmin) {
     return <Navigate to="/admin/login" state={{ from: location }} replace />;
   }
+  if (currentAdmin.role !== 'admin') {
+    return <Navigate to="/" state={{ from: location }} replace />;
+  }
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-purple-50 via-pink-50 to-orange-50 flex flex-col">

--- a/frontend/src/app/components/admin-protected-route.tsx
+++ b/frontend/src/app/components/admin-protected-route.tsx
@@ -1,9 +1,11 @@
 import { Navigate, Outlet, useLocation } from 'react-router';
 import { useAdmin } from '@/app/contexts/admin-context';
+import { useApp } from '@/app/contexts/app-context';
 import { AdminTopNav } from '@/app/components/admin-top-nav';
 
 export function AdminProtectedRoute() {
   const { currentAdmin, authLoading } = useAdmin();
+  const { currentUser } = useApp();
   const location = useLocation();
 
   if (authLoading) {
@@ -15,10 +17,16 @@ export function AdminProtectedRoute() {
   }
 
   if (!currentAdmin) {
+    if (currentUser?.role === 'student') {
+      return <Navigate to="/home" state={{ from: location }} replace />;
+    }
+    if (currentUser?.role === 'venue_manager') {
+      return <Navigate to="/venue/dashboard" state={{ from: location }} replace />;
+    }
     return <Navigate to="/admin/login" state={{ from: location }} replace />;
   }
   if (currentAdmin.role !== 'admin') {
-    return <Navigate to="/" state={{ from: location }} replace />;
+    return <Navigate to="/home" state={{ from: location }} replace />;
   }
 
   return (

--- a/frontend/src/app/components/admin-top-nav.tsx
+++ b/frontend/src/app/components/admin-top-nav.tsx
@@ -47,6 +47,10 @@ export function AdminTopNav() {
     backLink = '/admin/users';
     contextTitle = 'Edit User';
     contextSubtitle = 'Update user profile';
+  } else if (path === '/admin/moderation') {
+    isDynamic = true;
+    contextTitle = 'Moderation Queue';
+    contextSubtitle = 'Review flagged reviews and comments';
   }
 
   return (

--- a/frontend/src/app/components/protected-route.tsx
+++ b/frontend/src/app/components/protected-route.tsx
@@ -11,6 +11,12 @@ export function ProtectedRoute() {
   if (!currentUser) {
     return <Navigate to="/" state={{ from: location }} replace />;
   }
+  if (currentUser.role === 'admin') {
+    return <Navigate to="/admin/dashboard" replace />;
+  }
+  if (currentUser.role === 'venue_manager') {
+    return <Navigate to="/venue/dashboard" replace />;
+  }
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-purple-50 via-pink-50 to-orange-50 flex flex-col">

--- a/frontend/src/app/components/venue-protected-route.tsx
+++ b/frontend/src/app/components/venue-protected-route.tsx
@@ -1,9 +1,11 @@
 import { Navigate, Outlet, useLocation } from 'react-router';
 import { useVenue } from '@/app/contexts/venue-context';
+import { useApp } from '@/app/contexts/app-context';
 import { VenueTopNav } from '@/app/components/venue-top-nav';
 
 export function VenueProtectedRoute() {
   const { currentManager, authLoading } = useVenue();
+  const { currentUser } = useApp();
   const location = useLocation();
 
   // Wait for the session check to complete before deciding
@@ -16,10 +18,16 @@ export function VenueProtectedRoute() {
   }
 
   if (!currentManager) {
+    if (currentUser?.role === 'admin') {
+      return <Navigate to="/admin/dashboard" state={{ from: location }} replace />;
+    }
+    if (currentUser?.role === 'student') {
+      return <Navigate to="/home" state={{ from: location }} replace />;
+    }
     return <Navigate to="/venue/login" state={{ from: location }} replace />;
   }
   if (currentManager.role !== 'venue_manager') {
-    return <Navigate to="/" state={{ from: location }} replace />;
+    return <Navigate to="/home" state={{ from: location }} replace />;
   }
 
   return (

--- a/frontend/src/app/components/venue-protected-route.tsx
+++ b/frontend/src/app/components/venue-protected-route.tsx
@@ -18,6 +18,9 @@ export function VenueProtectedRoute() {
   if (!currentManager) {
     return <Navigate to="/venue/login" state={{ from: location }} replace />;
   }
+  if (currentManager.role !== 'venue_manager') {
+    return <Navigate to="/" state={{ from: location }} replace />;
+  }
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-purple-50 via-pink-50 to-orange-50 flex flex-col">

--- a/frontend/src/app/components/venue-protected-route.tsx
+++ b/frontend/src/app/components/venue-protected-route.tsx
@@ -26,9 +26,6 @@ export function VenueProtectedRoute() {
     }
     return <Navigate to="/venue/login" state={{ from: location }} replace />;
   }
-  if (currentManager.role !== 'venue_manager') {
-    return <Navigate to="/home" state={{ from: location }} replace />;
-  }
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-purple-50 via-pink-50 to-orange-50 flex flex-col">

--- a/frontend/src/app/contexts/app-context.tsx
+++ b/frontend/src/app/contexts/app-context.tsx
@@ -71,6 +71,7 @@ export interface SwipeEvent {
   name: string;
   status: 'pending' | 'active' | 'completed';
   createdAt: string;
+  scheduledFor?: string;
   matchedRestaurantId?: string;
   borough?: string;
   neighborhood?: string;
@@ -194,7 +195,14 @@ export interface AppContextType extends AuthContextType {
   currentGroup: Group | null;
   setCurrentGroup: (group: Group | null) => void;
   swipeEvents: SwipeEvent[];
-  createSwipeEvent: (groupId: string, name: string, borough?: string, neighborhood?: string, venueLimit?: number) => Promise<SwipeEvent>;
+  createSwipeEvent: (
+    groupId: string,
+    name: string,
+    borough?: string,
+    neighborhood?: string,
+    venueLimit?: number,
+    scheduledFor?: string
+  ) => Promise<SwipeEvent>;
   fetchSwipeEvents: (groupId: string, signal?: AbortSignal) => Promise<void>;
   currentSwipeEvent: SwipeEvent | null;
   setCurrentSwipeEvent: (event: SwipeEvent | null) => void;
@@ -763,13 +771,20 @@ function AppInner({ children }: { children: ReactNode }) {
     name: string,
     borough?: string,
     neighborhood?: string,
-    venueLimit?: number
+    venueLimit?: number,
+    scheduledFor?: string
   ): Promise<SwipeEvent> => {
     const res = await fetch(apiUrl(`/api/groups/${groupId}/events/`), {
       method: 'POST',
       credentials: 'include',
       headers: { 'Content-Type': 'application/json', 'X-CSRFToken': getCsrf() },
-      body: JSON.stringify({ name, borough, neighborhood, venue_limit: venueLimit || 10 }),
+      body: JSON.stringify({
+        name,
+        borough,
+        neighborhood,
+        venue_limit: venueLimit || 10,
+        scheduled_for: scheduledFor,
+      }),
     });
     const data = await res.json();
     if (!res.ok) throw new Error(data.error || 'Failed to create event');
@@ -779,6 +794,7 @@ function AppInner({ children }: { children: ReactNode }) {
       name: data.event.name,
       status: data.event.status,
       createdAt: data.event.created_at,
+      scheduledFor: data.event.scheduled_for || undefined,
       matchedRestaurantId: data.event.matched_venue_id ? String(data.event.matched_venue_id) : undefined,
       borough: data.event.borough || '',
       neighborhood: data.event.neighborhood || '',
@@ -800,15 +816,19 @@ function AppInner({ children }: { children: ReactNode }) {
         setSwipeEvents(
           data.events.map((e: {
             id: number; group_id: number; name: string; status: string;
-            created_at: string; matched_venue_id: number | null;
+            created_at: string; scheduled_for: string | null; matched_venue_id: number | null;
             total_participants: number; completed_participants_count: number;
+            borough?: string; neighborhood?: string;
           }) => ({
             id: String(e.id),
             groupId: String(e.group_id),
             name: e.name,
             status: e.status as SwipeEvent['status'],
             createdAt: e.created_at,
+            scheduledFor: e.scheduled_for || undefined,
             matchedRestaurantId: e.matched_venue_id ? String(e.matched_venue_id) : undefined,
+            borough: e.borough || '',
+            neighborhood: e.neighborhood || '',
             totalParticipants: e.total_participants,
             completedParticipantsCount: e.completed_participants_count,
           }))

--- a/frontend/src/app/contexts/venue-context.tsx
+++ b/frontend/src/app/contexts/venue-context.tsx
@@ -66,6 +66,53 @@ export interface StudentDiscount {
   updatedAt: string;
 }
 
+export interface ReviewAuthor {
+  id: string;
+  email: string;
+  name: string;
+  role: string;
+}
+
+export interface ReviewComment {
+  id: number;
+  content: string;
+  isManagerResponse: boolean;
+  isFlagged: boolean;
+  isVisible: boolean;
+  createdAt: string;
+  updatedAt: string;
+  author: ReviewAuthor;
+}
+
+export interface VenueReview {
+  id: number;
+  venueId: number;
+  rating: number;
+  title: string;
+  content: string;
+  visitDate: string;
+  additionalPhotos: string[];
+  isFlagged: boolean;
+  isVisible: boolean;
+  createdAt: string;
+  updatedAt: string;
+  author: ReviewAuthor;
+  comments: ReviewComment[];
+}
+
+export interface VenueReviewsPayload {
+  venue: {
+    id: number;
+    name: string;
+    streetAddress: string;
+    borough: string;
+    priceRange: string;
+    cuisineType: string;
+  };
+  canReply: boolean;
+  reviews: VenueReview[];
+}
+
 export interface ManagedVenue {
   id: number;
   name: string;
@@ -145,6 +192,8 @@ interface VenueContextType {
   claimVenue: (venueId: number, note?: string) => Promise<void>;
   fetchVenueDetail: (venueId: number) => Promise<ManagedVenue>;
   fetchDiscounts: (venueId: number) => Promise<StudentDiscount[]>;
+  fetchVenueReviews: (venueId: number) => Promise<VenueReviewsPayload>;
+  replyToReview: (venueId: number, reviewId: number, content: string) => Promise<ReviewComment>;
   createDiscount: (venueId: number, data: DiscountFormData) => Promise<StudentDiscount>;
   updateDiscount: (venueId: number, discountId: number, data: Partial<DiscountFormData>) => Promise<StudentDiscount>;
   deleteDiscount: (venueId: number, discountId: number) => Promise<void>;
@@ -295,6 +344,32 @@ export function VenueProvider({ children }: { children: ReactNode }) {
     return data.discounts ?? [];
   };
 
+  const fetchVenueReviews = async (venueId: number): Promise<VenueReviewsPayload> => {
+    const response = await fetch(apiUrl(`/api/venues/${venueId}/reviews/`), {
+      credentials: 'include',
+    });
+    const data = await response.json();
+    if (!response.ok || !data.success) {
+      throw new Error(data.error || 'Failed to fetch reviews');
+    }
+    return data as VenueReviewsPayload;
+  };
+
+  const replyToReview = async (venueId: number, reviewId: number, content: string): Promise<ReviewComment> => {
+    const csrftoken = getCsrf();
+    const response = await fetch(apiUrl(`/api/venues/${venueId}/reviews/${reviewId}/comments/`), {
+      method: 'POST',
+      credentials: 'include',
+      headers: { 'Content-Type': 'application/json', 'X-CSRFToken': csrftoken },
+      body: JSON.stringify({ content }),
+    });
+    const data = await response.json().catch(() => ({}));
+    if (!response.ok || !data.success) {
+      throw new Error(data.error || 'Failed to post reply');
+    }
+    return data.comment as ReviewComment;
+  };
+
   const createDiscount = async (venueId: number, formData: DiscountFormData): Promise<StudentDiscount> => {
     const csrftoken = getCsrf();
     const response = await fetch(apiUrl(`/api/venues/${venueId}/discounts/`), {
@@ -352,6 +427,8 @@ export function VenueProvider({ children }: { children: ReactNode }) {
       claimVenue,
       fetchVenueDetail,
       fetchDiscounts,
+      fetchVenueReviews,
+      replyToReview,
       createDiscount,
       updateDiscount,
       deleteDiscount,

--- a/frontend/src/app/pages/__tests__/admin-moderation-page.test.tsx
+++ b/frontend/src/app/pages/__tests__/admin-moderation-page.test.tsx
@@ -1,0 +1,161 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { BrowserRouter } from 'react-router';
+import { AdminModerationPage } from '../admin-moderation-page';
+
+const sampleReports = [
+  {
+    id: 1,
+    status: 'pending' as const,
+    reason: 'Harassment',
+    createdAt: new Date().toISOString(),
+    reviewedAt: null,
+    contentType: 'review' as const,
+    content: {
+      id: 10,
+      title: 'Bad place',
+      body: 'Something offensive',
+      venueName: 'Pizza Place',
+      authorEmail: 'author@nyu.edu',
+      authorName: 'Author Name',
+    },
+    reporter: { id: 5, email: 'reporter@nyu.edu', name: 'Reporter Name' },
+  },
+];
+
+function renderPage() {
+  return render(
+    <BrowserRouter>
+      <AdminModerationPage />
+    </BrowserRouter>
+  );
+}
+
+describe('AdminModerationPage', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('renders fetched reports with reason, reporter, author, and venue', async () => {
+    const fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ success: true, reports: sampleReports }),
+    } as Response);
+
+    renderPage();
+
+    await waitFor(() =>
+      expect(screen.getByText(/Pizza Place/)).toBeInTheDocument()
+    );
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(String(fetchMock.mock.calls[0][0])).toContain('status=pending');
+    expect(screen.getByText(/Harassment/)).toBeInTheDocument();
+    expect(screen.getByText(/Reporter Name/)).toBeInTheDocument();
+    expect(screen.getByText(/Author Name/)).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: /Confirm Violation/ })
+    ).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Reject Report/ })).toBeInTheDocument();
+  });
+
+  it('shows the empty state when no reports are returned', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ success: true, reports: [] }),
+    } as Response);
+
+    renderPage();
+
+    await waitFor(() =>
+      expect(screen.getByText(/No reports in this queue/)).toBeInTheDocument()
+    );
+  });
+
+  it('removes a report from the list after confirming', async () => {
+    const fetchMock = vi
+      .spyOn(globalThis, 'fetch')
+      // initial queue load
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ success: true, reports: sampleReports }),
+      } as Response)
+      // confirm action
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ success: true, report: { id: 1, status: 'confirmed' } }),
+      } as Response);
+
+    renderPage();
+
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: /Confirm Violation/ })).toBeInTheDocument()
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /Confirm Violation/ }));
+
+    await waitFor(() =>
+      expect(screen.getByText(/No reports in this queue/)).toBeInTheDocument()
+    );
+
+    const actionCall = fetchMock.mock.calls[1];
+    expect(String(actionCall[0])).toContain('/api/venues/admin/moderation/1/');
+    expect(JSON.parse(String(actionCall[1]?.body))).toEqual({ action: 'confirm' });
+  });
+
+  it('removes a report from the list after rejecting', async () => {
+    const fetchMock = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ success: true, reports: sampleReports }),
+      } as Response)
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ success: true, report: { id: 1, status: 'rejected' } }),
+      } as Response);
+
+    renderPage();
+
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: /Reject Report/ })).toBeInTheDocument()
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /Reject Report/ }));
+
+    await waitFor(() =>
+      expect(screen.getByText(/No reports in this queue/)).toBeInTheDocument()
+    );
+
+    expect(JSON.parse(String(fetchMock.mock.calls[1][1]?.body))).toEqual({
+      action: 'reject',
+    });
+  });
+
+  it('keeps the report in the list when the action call fails', async () => {
+    vi.spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ success: true, reports: sampleReports }),
+      } as Response)
+      .mockResolvedValueOnce({
+        ok: false,
+        json: async () => ({ success: false, error: 'nope' }),
+      } as Response);
+
+    renderPage();
+
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: /Confirm Violation/ })).toBeInTheDocument()
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /Confirm Violation/ }));
+
+    await waitFor(() =>
+      expect(screen.getByText(/Pizza Place/)).toBeInTheDocument()
+    );
+  });
+});

--- a/frontend/src/app/pages/__tests__/admin-users-page.test.tsx
+++ b/frontend/src/app/pages/__tests__/admin-users-page.test.tsx
@@ -1,0 +1,137 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { BrowserRouter } from 'react-router';
+import { AdminUsersPage } from '../admin-users-page';
+
+vi.mock('react-router', async () => {
+  const actual = await vi.importActual('react-router');
+  return {
+    ...(actual as Record<string, unknown>),
+    useNavigate: () => vi.fn(),
+  };
+});
+
+const baseUser = {
+  id: 1,
+  username: 'alice_student',
+  email: 'alice@test.local',
+  firstName: 'Alice',
+  lastName: 'Smith',
+  name: 'Alice Smith',
+  role: 'student' as const,
+  phone: '',
+  photoUrl: '',
+  isActive: true,
+  createdAt: '2025-01-01T00:00:00Z',
+};
+
+const inactiveUser = {
+  ...baseUser,
+  id: 2,
+  username: 'bob_student',
+  email: 'bob@test.local',
+  firstName: 'Bob',
+  lastName: 'Jones',
+  name: 'Bob Jones',
+  isActive: false,
+};
+
+function makeFetchMock() {
+  return vi.spyOn(globalThis, 'fetch').mockImplementation(async () => ({
+    ok: true,
+    json: async () => ({
+      users: [baseUser, inactiveUser],
+      totalPages: 1,
+      totalCount: 2,
+      page: 1,
+    }),
+  } as Response));
+}
+
+function renderPage() {
+  return render(
+    <BrowserRouter>
+      <AdminUsersPage />
+    </BrowserRouter>
+  );
+}
+
+describe('AdminUsersPage', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('renders username column and Banned badge for inactive users', async () => {
+    makeFetchMock();
+    renderPage();
+
+    await waitFor(() => expect(screen.getByText('alice_student')).toBeInTheDocument());
+    expect(screen.getByText('bob_student')).toBeInTheDocument();
+    expect(screen.getByText('Banned')).toBeInTheDocument();
+    // "Active" appears in the status filter dropdown too — find one inside the table
+    const table = screen.getByRole('table');
+    expect(table.textContent).toContain('Active');
+    expect(screen.getByRole('columnheader', { name: 'Username' })).toBeInTheDocument();
+    expect(screen.getByRole('columnheader', { name: 'Email' })).toBeInTheDocument();
+  });
+
+  it('does not send q when input has 3 or fewer characters', async () => {
+    const fetchMock = makeFetchMock();
+    renderPage();
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+
+    fireEvent.change(screen.getByPlaceholderText(/Email or username/), {
+      target: { value: 'ali' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /^Search$/ }));
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
+    const lastUrl = String(fetchMock.mock.calls.at(-1)?.[0]);
+    expect(lastUrl).not.toContain('q=');
+  });
+
+  it('sends trimmed q when input has more than 3 characters', async () => {
+    const fetchMock = makeFetchMock();
+    renderPage();
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+
+    fireEvent.change(screen.getByPlaceholderText(/Email or username/), {
+      target: { value: '  alice  ' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /^Search$/ }));
+
+    await waitFor(() => {
+      const calls = fetchMock.mock.calls.map((c) => String(c[0]));
+      expect(calls.some((url) => url.includes('q=alice'))).toBe(true);
+      expect(calls.some((url) => url.includes('q=+'))).toBe(false);
+    });
+  });
+
+  it('clear button resets query/role/status filters', async () => {
+    const fetchMock = makeFetchMock();
+    renderPage();
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+
+    const input = screen.getByPlaceholderText(/Email or username/) as HTMLInputElement;
+    fireEvent.change(input, { target: { value: 'alice' } });
+    fireEvent.click(screen.getByRole('button', { name: /^Search$/ }));
+
+    await waitFor(() => {
+      const calls = fetchMock.mock.calls.map((c) => String(c[0]));
+      expect(calls.some((url) => url.includes('q=alice'))).toBe(true);
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: /Clear/ }));
+
+    await waitFor(() => {
+      expect(input.value).toBe('');
+      const calls = fetchMock.mock.calls.map((c) => String(c[0]));
+      // Most recent call after clear should have no q
+      expect(calls.at(-1)).not.toContain('q=');
+    });
+  });
+});

--- a/frontend/src/app/pages/__tests__/review-pages.test.tsx
+++ b/frontend/src/app/pages/__tests__/review-pages.test.tsx
@@ -1,0 +1,166 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+import { BrowserRouter } from 'react-router';
+import { ReviewVenuePage } from '../review-venue-page';
+import { VenueReviewsPage } from '../venue-reviews-page';
+
+const mockUseParams = vi.fn();
+const mockUseSearchParams = vi.fn();
+const mockUseApp = vi.fn();
+const mockUseVenue = vi.fn();
+
+vi.mock('react-router', async () => {
+  const actual = await vi.importActual('react-router');
+  return {
+    ...actual as Record<string, unknown>,
+    useNavigate: () => vi.fn(),
+    useParams: () => mockUseParams(),
+    useSearchParams: () => mockUseSearchParams(),
+  };
+});
+
+vi.mock('@/app/contexts/app-context', () => ({
+  useApp: () => mockUseApp(),
+}));
+
+vi.mock('@/app/contexts/venue-context', () => ({
+  useVenue: () => mockUseVenue(),
+}));
+
+describe('review pages', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseParams.mockReturnValue({ venueId: '12' });
+    mockUseSearchParams.mockReturnValue([new URLSearchParams('eventId=event-1'), vi.fn()]);
+    mockUseApp.mockReturnValue({
+      currentUser: { id: '1', name: 'Student One', email: 'student@nyu.edu' },
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('submits a venue review with additional photos', async () => {
+    const fetchMock = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          success: true,
+          venue: {
+            id: 12,
+            name: 'Test Venue',
+            streetAddress: '1 Broadway',
+            borough: 'Manhattan',
+            priceRange: '$$',
+            cuisineType: 'Pizza',
+          },
+          reviews: [],
+        }),
+      } as Response)
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          success: true,
+          review: {
+            id: 9,
+          },
+        }),
+      } as Response);
+
+    render(
+      <BrowserRouter>
+        <ReviewVenuePage />
+      </BrowserRouter>
+    );
+
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: 'Submit Review' })).toBeInTheDocument()
+    );
+
+    fireEvent.change(screen.getByLabelText('Title'), { target: { value: 'Great meal' } });
+    fireEvent.change(screen.getByLabelText('Review'), { target: { value: 'Worth it.' } });
+    fireEvent.change(screen.getByLabelText('Additional Photo URLs'), {
+      target: { value: 'https://example.com/1.jpg, https://example.com/2.jpg' },
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Submit Review' }));
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
+    const postCall = fetchMock.mock.calls[1];
+    expect(String(postCall[0])).toContain('/api/venues/12/reviews/');
+    expect(JSON.parse(String(postCall[1]?.body))).toMatchObject({
+      rating: 5,
+      title: 'Great meal',
+      content: 'Worth it.',
+      visitDate: expect.any(String),
+      additionalPhotos: ['https://example.com/1.jpg', 'https://example.com/2.jpg'],
+    });
+  });
+
+  it('posts an owner response from the venue reviews page', async () => {
+    const replyMock = vi.fn().mockResolvedValue({
+      id: 1,
+      content: 'Thanks for the feedback.',
+      isManagerResponse: true,
+      isFlagged: false,
+      isVisible: true,
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+      author: { id: '9', email: 'manager@nyu.edu', name: 'Manager', role: 'venue_manager' },
+    });
+
+    mockUseVenue.mockReturnValue({
+      fetchVenueReviews: vi.fn().mockResolvedValue({
+        venue: {
+          id: 12,
+          name: 'Test Venue',
+          streetAddress: '1 Broadway',
+          borough: 'Manhattan',
+          priceRange: '$$',
+          cuisineType: 'Pizza',
+        },
+        canReply: true,
+        reviews: [
+          {
+            id: 7,
+            venueId: 12,
+            rating: 4,
+            title: 'Nice',
+            content: 'Good food.',
+            visitDate: '2025-01-01',
+            additionalPhotos: [],
+            isFlagged: false,
+            isVisible: true,
+            createdAt: new Date().toISOString(),
+            updatedAt: new Date().toISOString(),
+            author: {
+              id: '1',
+              email: 'student@nyu.edu',
+              name: 'Student One',
+              role: 'student',
+            },
+            comments: [],
+          },
+        ],
+      }),
+      replyToReview: replyMock,
+    });
+
+    render(
+      <BrowserRouter>
+        <VenueReviewsPage />
+      </BrowserRouter>
+    );
+
+    await waitFor(() => expect(screen.getByText('Test Venue')).toBeInTheDocument());
+
+    fireEvent.change(screen.getByLabelText('Owner Response'), {
+      target: { value: 'Thanks for the feedback.' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Post Response' }));
+
+    await waitFor(() => expect(replyMock).toHaveBeenCalledWith(12, 7, 'Thanks for the feedback.'));
+  });
+});

--- a/frontend/src/app/pages/admin-dashboard-page.tsx
+++ b/frontend/src/app/pages/admin-dashboard-page.tsx
@@ -1,7 +1,7 @@
 import { useNavigate } from 'react-router';
 import { useAdmin } from '@/app/contexts/admin-context';
 import { Card, CardDescription, CardHeader, CardTitle } from '@/app/components/ui/card';
-import { Users, ShieldCheck, Store, UserPlus } from 'lucide-react';
+import { Users, ShieldCheck, Store, UserPlus, Flag } from 'lucide-react';
 
 export function AdminDashboardPage() {
   const { currentAdmin } = useAdmin();
@@ -77,6 +77,21 @@ export function AdminDashboardPage() {
             <CardTitle className="mb-2">Add New Admin</CardTitle>
             <CardDescription>
               Register a new administrator account
+            </CardDescription>
+          </CardHeader>
+        </Card>
+
+        <Card
+          className="cursor-pointer hover:shadow-lg transition-shadow"
+          onClick={() => navigate('/admin/moderation')}
+        >
+          <CardHeader className="pb-6">
+            <div className="w-12 h-12 bg-red-100 rounded-xl flex items-center justify-center mb-3">
+              <Flag className="w-6 h-6 text-red-600" />
+            </div>
+            <CardTitle className="mb-2">Moderation Queue</CardTitle>
+            <CardDescription>
+              Review flagged reviews and comments
             </CardDescription>
           </CardHeader>
         </Card>

--- a/frontend/src/app/pages/admin-moderation-page.tsx
+++ b/frontend/src/app/pages/admin-moderation-page.tsx
@@ -1,0 +1,134 @@
+import { useCallback, useEffect, useState } from 'react';
+import { Button } from '@/app/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/app/components/ui/card';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/app/components/ui/select';
+import { Badge } from '@/app/components/ui/badge';
+import { apiUrl } from '@/app/lib/api';
+
+type ReportStatus = 'pending' | 'confirmed' | 'rejected';
+
+interface ModerationReport {
+  id: number;
+  status: ReportStatus;
+  reason: string;
+  createdAt: string;
+  reviewedAt: string | null;
+  contentType: 'review' | 'comment';
+  content: {
+    id: number;
+    title: string;
+    body: string;
+    venueName: string;
+    authorEmail: string;
+    authorName: string;
+  };
+  reporter: {
+    id: number;
+    email: string;
+    name: string;
+  };
+}
+
+export function AdminModerationPage() {
+  const [reports, setReports] = useState<ModerationReport[]>([]);
+  const [status, setStatus] = useState<ReportStatus>('pending');
+  const [loading, setLoading] = useState(false);
+
+  const fetchReports = useCallback(async () => {
+    setLoading(true);
+    try {
+      const response = await fetch(apiUrl(`/api/venues/admin/moderation/?status=${status}`), {
+        credentials: 'include',
+      });
+      const data = await response.json().catch(() => ({}));
+      if (response.ok && data.success) {
+        setReports(data.reports ?? []);
+      }
+    } finally {
+      setLoading(false);
+    }
+  }, [status]);
+
+  useEffect(() => {
+    fetchReports();
+  }, [fetchReports]);
+
+  const takeAction = async (reportId: number, action: 'confirm' | 'reject') => {
+    const response = await fetch(apiUrl(`/api/venues/admin/moderation/${reportId}/`), {
+      method: 'POST',
+      credentials: 'include',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ action }),
+    });
+    const data = await response.json().catch(() => ({}));
+    if (!response.ok || !data.success) return;
+    setReports((prev) => prev.filter((report) => report.id !== reportId));
+  };
+
+  return (
+    <div className="max-w-5xl mx-auto px-4 py-8 space-y-6">
+      <div className="flex items-center justify-between">
+        <h2 className="text-2xl font-semibold">Moderation Queue</h2>
+        <div className="w-44">
+          <Select value={status} onValueChange={(value) => setStatus(value as ReportStatus)}>
+            <SelectTrigger>
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="pending">Pending</SelectItem>
+              <SelectItem value="confirmed">Confirmed</SelectItem>
+              <SelectItem value="rejected">Rejected</SelectItem>
+            </SelectContent>
+          </Select>
+        </div>
+      </div>
+
+      {loading ? (
+        <p className="text-muted-foreground">Loading moderation queue...</p>
+      ) : reports.length === 0 ? (
+        <Card>
+          <CardContent className="py-10 text-center text-muted-foreground">
+            No reports in this queue.
+          </CardContent>
+        </Card>
+      ) : (
+        <div className="space-y-4">
+          {reports.map((report) => (
+            <Card key={report.id}>
+              <CardHeader className="pb-3">
+                <div className="flex items-center justify-between gap-3">
+                  <CardTitle className="text-lg">
+                    {report.contentType === 'review' ? 'Review' : 'Comment'} on {report.content.venueName}
+                  </CardTitle>
+                  <Badge variant="outline">{report.status}</Badge>
+                </div>
+              </CardHeader>
+              <CardContent className="space-y-3">
+                <p className="text-sm"><span className="font-medium">Reporter:</span> {report.reporter.name} ({report.reporter.email})</p>
+                <p className="text-sm"><span className="font-medium">Author:</span> {report.content.authorName} ({report.content.authorEmail})</p>
+                <p className="text-sm"><span className="font-medium">Reason:</span> {report.reason}</p>
+                <p className="text-sm"><span className="font-medium">Content:</span> {report.content.title ? `${report.content.title} — ` : ''}{report.content.body || 'No text provided'}</p>
+                {report.status === 'pending' && (
+                  <div className="flex gap-2 pt-2">
+                    <Button
+                      variant="destructive"
+                      onClick={() => takeAction(report.id, 'confirm')}
+                    >
+                      Confirm Violation
+                    </Button>
+                    <Button
+                      variant="outline"
+                      onClick={() => takeAction(report.id, 'reject')}
+                    >
+                      Reject Report
+                    </Button>
+                  </div>
+                )}
+              </CardContent>
+            </Card>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/app/pages/admin-users-page.tsx
+++ b/frontend/src/app/pages/admin-users-page.tsx
@@ -11,12 +11,13 @@ import {
   SelectValue,
 } from '@/app/components/ui/select';
 import { UserAvatar } from '@/app/components/user-avatar';
-import { Search, ChevronLeft, ChevronRight, Pencil } from 'lucide-react';
+import { Search, ChevronLeft, ChevronRight, Pencil, X } from 'lucide-react';
 
 const API = import.meta.env.VITE_API_BASE_URL ?? 'http://127.0.0.1:8000';
 
 interface UserRow {
   id: number;
+  username: string;
   email: string;
   firstName: string;
   lastName: string;
@@ -68,7 +69,8 @@ export function AdminUsersPage() {
     setLoading(true);
     try {
       const params = new URLSearchParams();
-      if (query) params.set('q', query);
+      const trimmedQuery = query.trim();
+      if (trimmedQuery.length > 3) params.set('q', trimmedQuery);
       if (role) params.set('role', role);
       if (status) params.set('status', status);
       params.set('page', String(page));
@@ -112,7 +114,7 @@ export function AdminUsersPage() {
             <Input
               value={query}
               onChange={(e) => setQuery(e.target.value)}
-              placeholder="Email or name…"
+              placeholder="Email or username (min 4 chars)…"
               className="pl-9"
             />
           </div>
@@ -166,6 +168,20 @@ export function AdminUsersPage() {
         >
           Search
         </Button>
+        <Button
+          type="button"
+          variant="outline"
+          className="h-10"
+          onClick={() => {
+            setQuery('');
+            setRole('');
+            setStatus('');
+            setPage(1);
+          }}
+        >
+          <X className="w-4 h-4 mr-1" />
+          Clear
+        </Button>
       </form>
 
       {loading ? (
@@ -183,9 +199,10 @@ export function AdminUsersPage() {
             <table className="w-full text-sm">
               <thead>
                 <tr className="border-b bg-muted/50">
-                  <th className="text-left px-4 py-3 font-semibold">User</th>
-                  <th className="text-left px-4 py-3 font-semibold">Role</th>
+                  <th className="text-left px-4 py-3 font-semibold">Username</th>
+                  <th className="text-left px-4 py-3 font-semibold">Email</th>
                   <th className="text-left px-4 py-3 font-semibold">Status</th>
+                  <th className="text-left px-4 py-3 font-semibold">Role</th>
                   <th className="text-left px-4 py-3 font-semibold">Joined</th>
                   <th className="text-right px-4 py-3 font-semibold">Action</th>
                 </tr>
@@ -196,9 +213,9 @@ export function AdminUsersPage() {
                     key={u.id}
                     className="border-b last:border-b-0 hover:bg-muted/30 cursor-pointer"
                     onClick={() => navigate(`/admin/users/${u.id}`)}
-                  >
-                    <td className="px-4 py-3">
-                      <div className="flex items-center gap-3">
+                    >
+                      <td className="px-4 py-3">
+                        <div className="flex items-center gap-3">
                         <UserAvatar
                           name={u.name}
                           email={u.email}
@@ -207,21 +224,13 @@ export function AdminUsersPage() {
                         />
                         <div>
                           <div className="font-medium">
-                            {u.name || '—'}
-                          </div>
-                          <div className="text-xs text-muted-foreground">
-                            {u.email}
+                            {u.username || u.name || '—'}
                           </div>
                         </div>
                       </div>
                     </td>
                     <td className="px-4 py-3">
-                      <Badge
-                        variant="outline"
-                        className={`text-xs ${ROLE_BADGE_CLASS[u.role]}`}
-                      >
-                        {ROLE_LABELS[u.role]}
-                      </Badge>
+                      <span className="text-sm text-muted-foreground">{u.email}</span>
                     </td>
                     <td className="px-4 py-3">
                       {u.isActive ? (
@@ -236,9 +245,17 @@ export function AdminUsersPage() {
                           variant="outline"
                           className="bg-red-50 text-red-600 border-red-200 text-xs"
                         >
-                          Inactive
+                          Banned
                         </Badge>
                       )}
+                    </td>
+                    <td className="px-4 py-3">
+                      <Badge
+                        variant="outline"
+                        className={`text-xs ${ROLE_BADGE_CLASS[u.role]}`}
+                      >
+                        {ROLE_LABELS[u.role]}
+                      </Badge>
                     </td>
                     <td className="px-4 py-3 text-muted-foreground">
                       {formatDate(u.createdAt)}

--- a/frontend/src/app/pages/group-detail-page.tsx
+++ b/frontend/src/app/pages/group-detail-page.tsx
@@ -813,16 +813,22 @@ export function GroupDetailPage() {
                           {event.name}
                         </CardTitle>
                         <CardDescription>
+                          Scheduled:{' '}
                           {new Date(
-                            event.createdAt,
-                          ).toLocaleDateString()}{" "}
-                          at{" "}
+                            event.scheduledFor || event.createdAt,
+                          ).toLocaleDateString()}{' '}
+                          at{' '}
                           {new Date(
-                            event.createdAt,
+                            event.scheduledFor || event.createdAt,
                           ).toLocaleTimeString([], {
                             hour: "2-digit",
                             minute: "2-digit",
                           })}
+                          {(event.neighborhood || event.borough) && (
+                            <span className="block mt-1">
+                              Location: {[event.neighborhood, event.borough].filter(Boolean).join(', ')}
+                            </span>
+                          )}
                           {event.totalParticipants !== undefined && event.completedParticipantsCount !== undefined && (
                             <span className="block mt-1 font-medium text-purple-600">
                               {event.completedParticipantsCount} of {event.totalParticipants} members finished swiping

--- a/frontend/src/app/pages/match-page.tsx
+++ b/frontend/src/app/pages/match-page.tsx
@@ -124,6 +124,14 @@ export function MatchPage() {
                 <div className="mb-6">
                   <RestaurantCard restaurant={matchedRestaurant} isReadonly={true} />
                 </div>
+                <div className="mb-3">
+                  <Button
+                    className="w-full bg-gradient-to-r from-purple-600 to-pink-600 hover:from-purple-700 hover:to-pink-700 text-white"
+                    onClick={() => navigate(`/venues/${matchedRestaurant.id}/review?eventId=${event.id}`)}
+                  >
+                    Leave a Review
+                  </Button>
+                </div>
                 <Button
                   variant="outline"
                   className="w-full"

--- a/frontend/src/app/pages/plan-event-page.tsx
+++ b/frontend/src/app/pages/plan-event-page.tsx
@@ -142,8 +142,16 @@ export function PlanEventPage() {
     }
 
     const finalName = eventName || `Dining Plan - ${locationString}`;
+    const scheduledFor = `${date}T${time}`;
     try {
-      const newEvent = await createSwipeEvent(group.id, finalName, eventBorough, eventNeighborhood, Number(venueLimit));
+      const newEvent = await createSwipeEvent(
+        group.id,
+        finalName,
+        eventBorough,
+        eventNeighborhood,
+        Number(venueLimit),
+        scheduledFor
+      );
       setCurrentGroup(group);
       setCurrentSwipeEvent(newEvent);
       navigate(`/swipe/${newEvent.id}`);

--- a/frontend/src/app/pages/plan-event-page.tsx
+++ b/frontend/src/app/pages/plan-event-page.tsx
@@ -115,6 +115,11 @@ export function PlanEventPage() {
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
 
+    if (!date || !time) {
+      console.warn('Date and time are required to schedule a session.');
+      return;
+    }
+
     // Build location string and determine borough/neighborhood for filtering
     let locationString = "";
     let eventBorough = "";

--- a/frontend/src/app/pages/review-venue-page.tsx
+++ b/frontend/src/app/pages/review-venue-page.tsx
@@ -1,0 +1,243 @@
+import { useEffect, useState } from 'react';
+import { useNavigate, useParams, useSearchParams } from 'react-router';
+import { useApp } from '@/app/contexts/app-context';
+import { apiUrl, getCsrf } from '@/app/lib/api';
+import { Button } from '@/app/components/ui/button';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/app/components/ui/card';
+import { Input } from '@/app/components/ui/input';
+import { Label } from '@/app/components/ui/label';
+import { Textarea } from '@/app/components/ui/textarea';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/app/components/ui/select';
+import { ArrowLeft, Star } from 'lucide-react';
+
+interface ReviewVenueSummary {
+  id: number;
+  name: string;
+  streetAddress: string;
+  borough: string;
+  priceRange: string;
+  cuisineType: string;
+}
+
+export function ReviewVenuePage() {
+  const { venueId } = useParams<{ venueId: string }>();
+  const [searchParams] = useSearchParams();
+  const navigate = useNavigate();
+  const { currentUser } = useApp();
+
+  const [venue, setVenue] = useState<ReviewVenueSummary | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState('');
+  const [success, setSuccess] = useState('');
+  const [rating, setRating] = useState('5');
+  const [title, setTitle] = useState('');
+  const [content, setContent] = useState('');
+  const [visitDate, setVisitDate] = useState(new Date().toISOString().slice(0, 10));
+  const [additionalPhotos, setAdditionalPhotos] = useState('');
+
+  useEffect(() => {
+    if (!venueId) return;
+    const id = Number.parseInt(venueId, 10);
+    if (Number.isNaN(id)) {
+      setError('Venue not found.');
+      setLoading(false);
+      return;
+    }
+
+    let cancelled = false;
+    const load = async () => {
+      try {
+        const response = await fetch(apiUrl(`/api/venues/${id}/reviews/`), {
+          credentials: 'include',
+        });
+        const data = await response.json().catch(() => ({}));
+        if (!response.ok || !data.success) {
+          throw new Error(data.error || 'Failed to load venue');
+        }
+        if (!cancelled) {
+          setVenue(data.venue as ReviewVenueSummary);
+          setError('');
+        }
+      } catch (err: unknown) {
+        if (!cancelled) {
+          setError(err instanceof Error ? err.message : 'Failed to load venue');
+        }
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    };
+    load();
+    return () => {
+      cancelled = true;
+    };
+  }, [venueId]);
+
+  const handleSubmit = async () => {
+    if (!venueId) return;
+    const id = Number.parseInt(venueId, 10);
+    if (Number.isNaN(id)) {
+      setError('Venue not found.');
+      return;
+    }
+
+    const photoList = additionalPhotos
+      .split(/[\n,]/)
+      .map((value) => value.trim())
+      .filter(Boolean);
+
+    setSaving(true);
+    setError('');
+    try {
+      const response = await fetch(apiUrl(`/api/venues/${id}/reviews/`), {
+        method: 'POST',
+        credentials: 'include',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-CSRFToken': getCsrf(),
+        },
+        body: JSON.stringify({
+          rating: Number.parseInt(rating, 10),
+          title,
+          content,
+          visitDate,
+          additionalPhotos: photoList,
+        }),
+      });
+      const data = await response.json().catch(() => ({}));
+      if (!response.ok || !data.success) {
+        throw new Error(data.error || 'Failed to submit review');
+      }
+      setSuccess('Review submitted successfully.');
+      setTitle('');
+      setContent('');
+      setAdditionalPhotos('');
+      const eventId = searchParams.get('eventId');
+      if (eventId) {
+        setTimeout(() => navigate(`/match/${eventId}`), 1200);
+      }
+    } catch (err: unknown) {
+      setError(err instanceof Error ? err.message : 'Failed to submit review');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  if (loading) {
+    return (
+      <div className="min-h-screen flex items-center justify-center">
+        <div className="text-center">
+          <div className="rounded-full h-10 w-10 border-4 border-purple-500 border-t-transparent animate-spin mx-auto mb-3" />
+          <p className="text-muted-foreground text-sm">Loading review form…</p>
+        </div>
+      </div>
+    );
+  }
+
+  if (error && !venue) {
+    return (
+      <div className="min-h-screen flex items-center justify-center px-4">
+        <div className="text-center space-y-4">
+          <p className="text-red-600">{error}</p>
+          <Button onClick={() => navigate('/home')}>
+            <ArrowLeft className="w-4 h-4 mr-2" />
+            Back to Home
+          </Button>
+        </div>
+      </div>
+    );
+  }
+
+  if (!venue) return null;
+
+  return (
+    <main className="max-w-3xl mx-auto px-4 py-8 space-y-6">
+      <Button variant="ghost" className="px-0" onClick={() => navigate(-1)}>
+        <ArrowLeft className="w-4 h-4 mr-2" />
+        Back
+      </Button>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-2xl flex items-center gap-2">
+            <Star className="w-5 h-5 fill-yellow-400 text-yellow-400" />
+            Write a Review
+          </CardTitle>
+          <CardDescription>
+            {venue.name}{venue.cuisineType ? ` · ${venue.cuisineType}` : ''}{venue.priceRange ? ` · ${venue.priceRange}` : ''}
+            {currentUser?.name ? ` · by ${currentUser.name}` : ''}
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          {error && <p className="text-sm text-red-600">{error}</p>}
+          {success && <p className="text-sm text-green-700">{success}</p>}
+
+          <div className="grid md:grid-cols-2 gap-4">
+            <div className="space-y-2">
+              <Label htmlFor="rating">Rating</Label>
+              <Select value={rating} onValueChange={setRating}>
+                <SelectTrigger id="rating">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="5">5 — Excellent</SelectItem>
+                  <SelectItem value="4">4 — Good</SelectItem>
+                  <SelectItem value="3">3 — OK</SelectItem>
+                  <SelectItem value="2">2 — Weak</SelectItem>
+                  <SelectItem value="1">1 — Poor</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="visitDate">Visit Date</Label>
+              <Input
+                id="visitDate"
+                type="date"
+                value={visitDate}
+                onChange={(event) => setVisitDate(event.target.value)}
+              />
+            </div>
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="title">Title</Label>
+            <Input
+              id="title"
+              placeholder="Optional title"
+              value={title}
+              onChange={(event) => setTitle(event.target.value)}
+            />
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="content">Review</Label>
+            <Textarea
+              id="content"
+              placeholder="Tell other students what stood out"
+              rows={6}
+              value={content}
+              onChange={(event) => setContent(event.target.value)}
+            />
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="additionalPhotos">Additional Photo URLs</Label>
+            <Textarea
+              id="additionalPhotos"
+              placeholder="Paste one or more image URLs, separated by commas or new lines"
+              rows={4}
+              value={additionalPhotos}
+              onChange={(event) => setAdditionalPhotos(event.target.value)}
+            />
+          </div>
+
+          <div className="flex justify-end">
+            <Button onClick={handleSubmit} disabled={saving}>
+              {saving ? 'Submitting…' : 'Submit Review'}
+            </Button>
+          </div>
+        </CardContent>
+      </Card>
+    </main>
+  );
+}

--- a/frontend/src/app/pages/venue-dashboard-page.tsx
+++ b/frontend/src/app/pages/venue-dashboard-page.tsx
@@ -216,18 +216,25 @@ export function VenueDashboardPage() {
                             Last inspection: {new Date(venue.lastInspectionDate).toLocaleDateString()}
                           </p>
                         )}
+                        <div className="flex flex-wrap gap-2 pt-2">
+                          <Button
+                            variant="outline"
+                            size="sm"
+                            onClick={() => navigate(`/venue/venue/${venue.id}/discounts`)}
+                          >
+                            Manage Discounts
+                          </Button>
+                          <Button
+                            variant="outline"
+                            size="sm"
+                            onClick={() => navigate(`/venue/venue/${venue.id}/reviews`)}
+                          >
+                            View Reviews
+                          </Button>
+                        </div>
                       </div>
                     </div>
 
-                    <div className="pt-3 border-t flex items-center justify-end gap-2">
-                      <Button
-                        variant="outline"
-                        size="sm"
-                        onClick={() => navigate(`/venue/venue/${venue.id}/discounts`)}
-                      >
-                        Manage Discounts
-                      </Button>
-                    </div>
                   </CardContent>
                 </Card>
               );

--- a/frontend/src/app/pages/venue-reviews-page.tsx
+++ b/frontend/src/app/pages/venue-reviews-page.tsx
@@ -88,9 +88,6 @@ export function VenueReviewsPage() {
     }
   };
 
-  const stars = (rating: number) =>
-    Array.from({ length: 5 }, (_, index) => index < rating);
-
   if (loading) {
     return (
       <div className="min-h-screen flex items-center justify-center">

--- a/frontend/src/app/pages/venue-reviews-page.tsx
+++ b/frontend/src/app/pages/venue-reviews-page.tsx
@@ -1,0 +1,267 @@
+import { useEffect, useMemo, useState } from 'react';
+import { useNavigate, useParams } from 'react-router';
+import { useVenue } from '@/app/contexts/venue-context';
+import type { VenueReview, VenueReviewsPayload } from '@/app/contexts/venue-context';
+import { Button } from '@/app/components/ui/button';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/app/components/ui/card';
+import { Badge } from '@/app/components/ui/badge';
+import { Label } from '@/app/components/ui/label';
+import { Textarea } from '@/app/components/ui/textarea';
+import { Star, ArrowLeft, MessageSquareReply, Image as ImageIcon } from 'lucide-react';
+
+export function VenueReviewsPage() {
+  const { venueId } = useParams<{ venueId: string }>();
+  const navigate = useNavigate();
+  const { fetchVenueReviews, replyToReview } = useVenue();
+
+  const [payload, setPayload] = useState<VenueReviewsPayload | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState('');
+  const [replyDrafts, setReplyDrafts] = useState<Record<number, string>>({});
+  const [replyingId, setReplyingId] = useState<number | null>(null);
+
+  useEffect(() => {
+    if (!venueId) return;
+    const id = Number.parseInt(venueId, 10);
+    if (Number.isNaN(id)) {
+      setError('Venue not found.');
+      setLoading(false);
+      return;
+    }
+
+    let cancelled = false;
+    const load = async () => {
+      try {
+        setLoading(true);
+        const data = await fetchVenueReviews(id);
+        if (!cancelled) {
+          setPayload(data);
+          setError('');
+        }
+      } catch (err: unknown) {
+        if (!cancelled) {
+          setError(err instanceof Error ? err.message : 'Failed to load reviews');
+        }
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    };
+    load();
+    return () => {
+      cancelled = true;
+    };
+  }, [venueId, fetchVenueReviews]);
+
+  const venue = payload?.venue;
+  const reviews = useMemo(() => payload?.reviews ?? [], [payload]);
+
+  const handleReply = async (review: VenueReview) => {
+    if (!venueId) return;
+    const text = (replyDrafts[review.id] || '').trim();
+    if (!text) {
+      setError('Reply content is required.');
+      return;
+    }
+
+    const numericVenueId = Number.parseInt(venueId, 10);
+    setReplyingId(review.id);
+    try {
+      const comment = await replyToReview(numericVenueId, review.id, text);
+      setPayload((current) =>
+        current
+          ? {
+              ...current,
+              reviews: current.reviews.map((item) =>
+                item.id === review.id
+                  ? { ...item, comments: [...item.comments, comment] }
+                  : item
+              ),
+            }
+          : current
+      );
+      setReplyDrafts((current) => ({ ...current, [review.id]: '' }));
+      setError('');
+    } catch (err: unknown) {
+      setError(err instanceof Error ? err.message : 'Failed to post reply');
+    } finally {
+      setReplyingId(null);
+    }
+  };
+
+  const stars = (rating: number) =>
+    Array.from({ length: 5 }, (_, index) => index < rating);
+
+  if (loading) {
+    return (
+      <div className="min-h-screen flex items-center justify-center">
+        <div className="text-center">
+          <div className="rounded-full h-10 w-10 border-4 border-orange-500 border-t-transparent animate-spin mx-auto mb-3" />
+          <p className="text-muted-foreground text-sm">Loading reviews…</p>
+        </div>
+      </div>
+    );
+  }
+
+  if (error && !payload) {
+    return (
+      <div className="min-h-screen flex items-center justify-center px-4">
+        <div className="text-center space-y-4">
+          <p className="text-red-600">{error}</p>
+          <Button onClick={() => navigate('/venue/dashboard')}>
+            <ArrowLeft className="w-4 h-4 mr-2" />
+            Back to Dashboard
+          </Button>
+        </div>
+      </div>
+    );
+  }
+
+  if (!venue) {
+    return null;
+  }
+
+  return (
+    <main className="max-w-5xl mx-auto px-4 py-8 space-y-6">
+      <div className="flex items-center justify-between gap-4">
+        <div>
+          <Button variant="ghost" className="mb-3 px-0" onClick={() => navigate('/venue/dashboard')}>
+            <ArrowLeft className="w-4 h-4 mr-2" />
+            Back to Dashboard
+          </Button>
+          <h1 className="text-3xl font-semibold">{venue.name}</h1>
+          <p className="text-muted-foreground mt-1">
+            {venue.cuisineType || 'Venue reviews'} · {venue.priceRange || 'No price range'}
+          </p>
+        </div>
+        <Badge variant="outline" className="self-start">
+          {reviews.length} review{reviews.length === 1 ? '' : 's'}
+        </Badge>
+      </div>
+
+      {error && (
+        <p className="text-sm text-red-600">{error}</p>
+      )}
+
+      {reviews.length === 0 ? (
+        <Card>
+          <CardContent className="py-10 text-center text-muted-foreground">
+            No reviews yet.
+          </CardContent>
+        </Card>
+      ) : (
+        <div className="space-y-4">
+          {reviews.map((review) => (
+            <Card key={review.id}>
+              <CardHeader className="pb-3">
+                <div className="flex items-start justify-between gap-3">
+                  <div className="space-y-2">
+                    <div className="flex items-center gap-2 flex-wrap">
+                      <CardTitle className="text-lg">{review.title || 'Untitled review'}</CardTitle>
+                      {!review.isVisible && (
+                        <Badge variant="destructive" className="text-xs">
+                          Hidden
+                        </Badge>
+                      )}
+                    </div>
+                    <CardDescription className="flex flex-wrap items-center gap-2">
+                      <span>{review.author.name}</span>
+                      <span>·</span>
+                      <span>{review.author.email}</span>
+                      <span>·</span>
+                      <span>{new Date(review.visitDate).toLocaleDateString()}</span>
+                    </CardDescription>
+                  </div>
+                  <Badge variant="secondary" className="flex items-center gap-1">
+                    <Star className="w-3.5 h-3.5 fill-current" />
+                    {review.rating}/5
+                  </Badge>
+                </div>
+              </CardHeader>
+              <CardContent className="space-y-4">
+                {review.content && <p className="text-sm leading-6">{review.content}</p>}
+
+                {review.additionalPhotos.length > 0 && (
+                  <div className="space-y-2">
+                    <p className="text-xs font-medium text-muted-foreground flex items-center gap-1">
+                      <ImageIcon className="w-3.5 h-3.5" />
+                      Additional photos
+                    </p>
+                    <div className="grid grid-cols-2 md:grid-cols-3 gap-2">
+                      {review.additionalPhotos.map((photo) => (
+                        <a
+                          key={photo}
+                          href={photo}
+                          target="_blank"
+                          rel="noreferrer"
+                          className="block rounded-md overflow-hidden border bg-muted"
+                        >
+                          <img src={photo} alt="Review upload" className="h-28 w-full object-cover" />
+                        </a>
+                      ))}
+                    </div>
+                  </div>
+                )}
+
+                <div className="space-y-2">
+                  <p className="text-xs font-medium text-muted-foreground">
+                    Responses
+                  </p>
+                  {review.comments.length === 0 ? (
+                    <p className="text-sm text-muted-foreground">No responses yet.</p>
+                  ) : (
+                    <div className="space-y-2">
+                      {review.comments.map((comment) => (
+                        <div key={comment.id} className="rounded-md border bg-muted/40 p-3 space-y-1">
+                          <div className="flex items-center gap-2 flex-wrap">
+                            <p className="text-sm font-medium">{comment.author.name}</p>
+                            {comment.isManagerResponse && (
+                              <Badge variant="outline" className="text-xs">
+                                Owner Response
+                              </Badge>
+                            )}
+                            {!comment.isVisible && (
+                              <Badge variant="destructive" className="text-xs">
+                                Hidden
+                              </Badge>
+                            )}
+                          </div>
+                          <p className="text-sm leading-6">{comment.content}</p>
+                        </div>
+                      ))}
+                    </div>
+                  )}
+                </div>
+
+                {payload?.canReply && (
+                  <div className="space-y-2 pt-2">
+                    <Label htmlFor={`reply-${review.id}`}>Owner Response</Label>
+                    <Textarea
+                      id={`reply-${review.id}`}
+                      value={replyDrafts[review.id] || ''}
+                      onChange={(event) =>
+                        setReplyDrafts((current) => ({
+                          ...current,
+                          [review.id]: event.target.value,
+                        }))
+                      }
+                      placeholder="Write a response to this review"
+                    />
+                    <div className="flex justify-end">
+                      <Button
+                        onClick={() => handleReply(review)}
+                        disabled={replyingId === review.id}
+                      >
+                        <MessageSquareReply className="w-4 h-4 mr-2" />
+                        {replyingId === review.id ? 'Posting…' : 'Post Response'}
+                      </Button>
+                    </div>
+                  </div>
+                )}
+              </CardContent>
+            </Card>
+          ))}
+        </div>
+      )}
+    </main>
+  );
+}

--- a/frontend/src/app/routes.ts
+++ b/frontend/src/app/routes.ts
@@ -9,9 +9,11 @@ import { GroupDetailPage } from '@/app/pages/group-detail-page';
 import { PlanEventPage } from '@/app/pages/plan-event-page';
 import { SwipePage } from '@/app/pages/swipe-page';
 import { MatchPage } from '@/app/pages/match-page';
+import { ReviewVenuePage } from '@/app/pages/review-venue-page';
 import { VenueDashboardPage } from '@/app/pages/venue-dashboard-page';
 import { ClaimVenuePage } from '@/app/pages/claim-venue-page';
 import { VenueDiscountPage } from '@/app/pages/venue-discount-page';
+import { VenueReviewsPage } from '@/app/pages/venue-reviews-page';
 import { VenueLoginPage } from '@/app/pages/venue-login-page';
 import { VenueRegisterPage } from '@/app/pages/venue-register-page';
 import { AdminLoginPage } from '@/app/pages/admin-login-page';
@@ -119,6 +121,10 @@ export const router = createBrowserRouter([
             path: 'venue/venue/:venueId/discounts',
             Component: VenueDiscountPage,
           },
+          {
+            path: 'venue/venue/:venueId/reviews',
+            Component: VenueReviewsPage,
+          },
         ],
       },
       // ── Student protected routes ─────────────────────────────────────
@@ -156,6 +162,10 @@ export const router = createBrowserRouter([
           {
             path: 'match/:eventId',
             Component: MatchPage,
+          },
+          {
+            path: 'venues/:venueId/review',
+            Component: ReviewVenuePage,
           },
         ],
       },

--- a/frontend/src/app/routes.ts
+++ b/frontend/src/app/routes.ts
@@ -23,6 +23,7 @@ import { AdminVenuesPage } from '@/app/pages/admin-venues-page';
 import { AdminVenueEditPage } from '@/app/pages/admin-venue-edit-page';
 import { AdminUsersPage } from '@/app/pages/admin-users-page';
 import { AdminUserEditPage } from '@/app/pages/admin-user-edit-page';
+import { AdminModerationPage } from '@/app/pages/admin-moderation-page';
 import { ResetPasswordPage } from '@/app/pages/reset-password-page';
 import { ProfileEditPage } from '@/app/pages/profile-edit-page';
 import { ProtectedRoute } from '@/app/components/protected-route';
@@ -86,6 +87,10 @@ export const router = createBrowserRouter([
           {
             path: 'admin/users/:userId',
             Component: AdminUserEditPage,
+          },
+          {
+            path: 'admin/moderation',
+            Component: AdminModerationPage,
           },
         ],
       },

--- a/frontend/src/test/setup.ts
+++ b/frontend/src/test/setup.ts
@@ -2,6 +2,56 @@ import '@testing-library/jest-dom';
 import { cleanup } from '@testing-library/react';
 import { afterEach, vi } from 'vitest';
 
+// Node.js >= 22 ships a built-in `localStorage` global as an empty object that
+// lacks Storage methods, and that broken object shadows jsdom's
+// `window.localStorage`. Code calling `localStorage.removeItem(...)` therefore
+// throws "is not a function". Replace both with a working in-memory Storage.
+function createMemoryStorage(): Storage {
+  let store: Record<string, string> = {};
+  return {
+    get length() {
+      return Object.keys(store).length;
+    },
+    clear() {
+      store = {};
+    },
+    getItem(key: string) {
+      return Object.prototype.hasOwnProperty.call(store, key) ? store[key] : null;
+    },
+    key(index: number) {
+      return Object.keys(store)[index] ?? null;
+    },
+    removeItem(key: string) {
+      delete store[key];
+    },
+    setItem(key: string, value: string) {
+      store[key] = String(value);
+    },
+  };
+}
+
+const memoryLocal = createMemoryStorage();
+const memorySession = createMemoryStorage();
+
+Object.defineProperty(globalThis, 'localStorage', {
+  configurable: true,
+  value: memoryLocal,
+});
+Object.defineProperty(globalThis, 'sessionStorage', {
+  configurable: true,
+  value: memorySession,
+});
+if (typeof window !== 'undefined') {
+  Object.defineProperty(window, 'localStorage', {
+    configurable: true,
+    value: memoryLocal,
+  });
+  Object.defineProperty(window, 'sessionStorage', {
+    configurable: true,
+    value: memorySession,
+  });
+}
+
 afterEach(() => {
   cleanup();
   vi.restoreAllMocks(); // restores spies created with vi.spyOn, clears all mocks


### PR DESCRIPTION
## Summary

### Role-based routing (#181)
- `ProtectedRoute` redirects admins to `/admin/dashboard` and venue managers to `/venue/dashboard` when they hit a student route by URL.
- `AdminProtectedRoute` / `VenueProtectedRoute` redirect cross-role users to their correct dashboard instead of the login page.

### Session details (#177, #117)
- Persist `scheduled_for` on `SwipeEvent` and surface the user-selected date/time + neighborhood in `GroupDetailPage`.
- Reject submission when date/time inputs are empty so the backend never gets a malformed datetime.

### Admin user search (#5)
- `q` is applied only when the trimmed query is longer than 3 characters; matches `username`, `email`, `first_name`, `last_name`.
- Admin users table now shows Username + Email columns, "Banned" badge for inactive accounts, and a Clear button that resets all filters.

### Content moderation (#6, #74, #75, #76, #77, #78)
- New `ContentReport` model with a check-constraint requiring exactly one of `review`/`comment`.
- Endpoints to report a review or comment, list pending/confirmed/rejected items, and confirm/reject as admin.
- Confirmed reports hide content from public venue pages; the author is emailed via `send_mail`.
- Reviewer + timestamp + status are persisted on the report as the audit trail.
- Bug fix on this branch: rejecting one report no longer unhides content that another confirmed report still wants hidden, and the flag is cleared only when no other open or confirmed reports remain.

### Reviews & owner responses (#20)
- Students can post reviews with up to 5 photo URLs from the matched venue page.
- Venue managers can view all reviews on their venues (including hidden ones) and post owner responses; non-managers get a 403.

### Group invites (#142)
- Invitee receives an email when a group invitation is created.

## Validation
- Backend: 576 tests pass; coverage 97% overall (`venues/views.py` 84% → 95%, `groups/views.py` 87% → 88%).
- Frontend: 44 tests pass, including new suites for the moderation queue, admin users page, route guards, and review pages. Login/register tests are fixed on this branch — Node 22+ ships a broken built-in `localStorage` global, so the test setup now installs an in-memory Storage.
- Frontend production build succeeds.

Closes #5
Closes #6
Closes #20
Closes #74
Closes #75
Closes #76
Closes #77
Closes #78
Closes #117
Closes #142
Closes #177
Closes #181
