### PR TITLE
Proxy /ws/ through frontend nginx with WebSocket upgrade

### DIFF
--- a/frontend/.platform/nginx/conf.d/elasticbeanstalk/10_api_proxy.conf
+++ b/frontend/.platform/nginx/conf.d/elasticbeanstalk/10_api_proxy.conf
@@ -13,3 +13,22 @@ location /api/ {
     proxy_read_timeout 60s;
     proxy_connect_timeout 60s;
 }
+
+location /ws/ {
+    resolver 169.254.169.253 valid=30s;
+    set $backend "BACKEND_EB_URL";
+    proxy_pass http://$backend;
+    proxy_http_version 1.1;
+
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection "upgrade";
+    proxy_set_header Host BACKEND_EB_URL;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_set_header X-Forwarded-Host $host;
+
+    proxy_read_timeout 3600s;
+    proxy_send_timeout 3600s;
+    proxy_connect_timeout 60s;
+}


### PR DESCRIPTION
The browser opens ws://<frontend-eb>/ws/notifications/ because the production build uses relative URLs, so all traffic — including WebSocket — lands on the frontend EB and is reverse-proxied to the backend. The existing 10_api_proxy.conf only handles /api/ and lacks Upgrade/Connection headers, so the WS handshake falls through to the static-file fallback and fails (readyState 3 / WebSocket error).

Add a /ws/ location alongside /api/ that forwards to the same BACKEND_EB_URL placeholder (already substituted by Travis at deploy time), passes the Upgrade and Connection headers, and uses a long read/send timeout so idle sockets aren't reaped by nginx mid-session.