### PR TITLE
feat: complete websocket implementation for swipe sessions and fix edge cases

### DIFF
--- a/backend/chat/consumers.py
+++ b/backend/chat/consumers.py
@@ -38,3 +38,16 @@ class UserNotificationConsumer(AsyncWebsocketConsumer):
         Handler for the 'notification_update' event to reload invites/activity.
         """
         await self.send(text_data=json.dumps({"type": "notification_update"}))
+
+    async def swipe_session_update(self, event):
+        """
+        Handler for the 'swipe_session_update' event to reload swipe session data.
+        """
+        await self.send(
+            text_data=json.dumps(
+                {
+                    "type": "swipe_session_update",
+                    "group_id": event.get("group_id"),
+                }
+            )
+        )

--- a/backend/chat/test_consumers.py
+++ b/backend/chat/test_consumers.py
@@ -58,6 +58,14 @@ class ConsumerCoverageTests(TransactionTestCase):
             text_data=json.dumps({"type": "notification_update"})
         )
 
+    async def test_swipe_session_update(self):
+        consumer = UserNotificationConsumer()
+        consumer.send = AsyncMock()
+        await consumer.swipe_session_update({"group_id": "123"})
+        consumer.send.assert_called_once_with(
+            text_data=json.dumps({"type": "swipe_session_update", "group_id": "123"})
+        )
+
     def test_routing(self):
         # Just to ensure routing.py is imported and the patterns are valid
         self.assertTrue(len(websocket_urlpatterns) > 0)

--- a/backend/groups/tests.py
+++ b/backend/groups/tests.py
@@ -1464,7 +1464,9 @@ class GroupManagementAPITests(TestCase):
         )
 
     def test_leave_group_completes_swipe_session(self):
-        event = SwipeEvent.objects.create(group=self.group, status="active")
+        event = SwipeEvent.objects.create(
+            group=self.group, name="Test Swipe Event", status="active"
+        )
         event.completed_by.add(self.leader)
         self.client.login(email="member@example.com", password="pass123")
         response = self.client.post(f"/api/groups/{self.group.id}/leave/")
@@ -1477,7 +1479,9 @@ class GroupManagementAPITests(TestCase):
 
         # Clear memberships to make total_participants = 0
         GroupMembership.objects.filter(group=self.group).delete()
-        event = SwipeEvent.objects.create(group=self.group, status="active")
+        event = SwipeEvent.objects.create(
+            group=self.group, name="Test Swipe Event", status="active"
+        )
 
         check_and_complete_active_swipe_events(self.group)
 

--- a/backend/groups/tests.py
+++ b/backend/groups/tests.py
@@ -1336,6 +1336,26 @@ class GroupManagementAPITests(TestCase):
             GroupMembership.objects.filter(user=self.member, group=self.group).exists()
         )
 
+    def test_remove_member_completes_swipe_session(self):
+        from groups.models import Swipe
+        from venues.models import Venue
+
+        event = SwipeEvent.objects.create(group=self.group, status="active")
+        venue = Venue.objects.create(name="Match Venue", is_active=True)
+        Swipe.objects.create(
+            event=event, user=self.leader, venue=venue, direction=Swipe.Direction.RIGHT
+        )
+        event.completed_by.add(self.leader)
+
+        self.client.login(email="leader@example.com", password="pass123")
+        response = self.client.delete(
+            f"/api/groups/{self.group.id}/members/{self.member.id}/"
+        )
+        self.assertEqual(response.status_code, 200)
+        event.refresh_from_db()
+        self.assertEqual(event.status, SwipeEvent.Status.COMPLETED)
+        self.assertEqual(event.matched_venue, venue)
+
     def test_remove_self_fails(self):
         self.client.login(email="leader@example.com", password="pass123")
         response = self.client.delete(
@@ -1440,6 +1460,27 @@ class GroupManagementAPITests(TestCase):
         self.assertFalse(
             GroupMembership.objects.filter(user=self.member, group=self.group).exists()
         )
+
+    def test_leave_group_completes_swipe_session(self):
+        event = SwipeEvent.objects.create(group=self.group, status="active")
+        event.completed_by.add(self.leader)
+        self.client.login(email="member@example.com", password="pass123")
+        response = self.client.post(f"/api/groups/{self.group.id}/leave/")
+        self.assertEqual(response.status_code, 200)
+        event.refresh_from_db()
+        self.assertEqual(event.status, SwipeEvent.Status.COMPLETED)
+
+    def test_helper_zero_participants_completes_session(self):
+        from groups.views import check_and_complete_active_swipe_events
+
+        # Clear memberships to make total_participants = 0
+        GroupMembership.objects.filter(group=self.group).delete()
+        event = SwipeEvent.objects.create(group=self.group, status="active")
+
+        check_and_complete_active_swipe_events(self.group)
+
+        event.refresh_from_db()
+        self.assertEqual(event.status, SwipeEvent.Status.COMPLETED)
 
     def test_leave_group_as_leader_with_another_leader(self):
         """Leader can leave if another leader exists."""

--- a/backend/groups/tests.py
+++ b/backend/groups/tests.py
@@ -1340,7 +1340,9 @@ class GroupManagementAPITests(TestCase):
         from groups.models import Swipe
         from venues.models import Venue
 
-        event = SwipeEvent.objects.create(group=self.group, status="active")
+        event = SwipeEvent.objects.create(
+            group=self.group, name="Test Swipe Event", status="active"
+        )
         venue = Venue.objects.create(name="Match Venue", is_active=True)
         Swipe.objects.create(
             event=event, user=self.leader, venue=venue, direction=Swipe.Direction.RIGHT

--- a/backend/groups/views.py
+++ b/backend/groups/views.py
@@ -545,6 +545,64 @@ def api_invitation_action(request, invitation_id, action):
         return JsonResponse({"error": "An expected error occurred"}, status=500)
 
 
+def check_and_complete_active_swipe_events(group):
+    """
+    Checks all active swipe events for the group. If the number of members who have
+    completed swiping is >= the new total_participants, computes the match and
+    marks the event as completed, then triggers a websocket update.
+    """
+    from .models import SwipeEvent, Swipe
+    from venues.models import Venue
+    import math
+    from django.db.models import Count
+    from channels.layers import get_channel_layer
+    from asgiref.sync import async_to_sync
+
+    active_events = group.swipe_events.filter(status=SwipeEvent.Status.ACTIVE)
+    total_participants = group.memberships.count()
+
+    # If total_participants drops to 0, we could cancel the events, but 0 threshold handles it somewhat.
+    if total_participants == 0:
+        for event in active_events:
+            event.status = SwipeEvent.Status.COMPLETED
+            event.save(update_fields=["status", "updated_at"])
+        return
+
+    for event in active_events:
+        completed_count = event.completed_by.count()
+        if completed_count >= total_participants:
+            all_swipes = event.swipes.all()
+            threshold = math.ceil(total_participants * 2 / 3)
+            venue_likes = (
+                all_swipes.filter(direction=Swipe.Direction.RIGHT)
+                .values("venue_id")
+                .annotate(like_count=Count("user_id", distinct=True))
+                .order_by("-like_count")
+            )
+
+            matched_venue = None
+            for entry in venue_likes:
+                if entry["like_count"] >= threshold:
+                    matched_venue = Venue.objects.get(id=entry["venue_id"])
+                    break
+
+            if matched_venue:
+                event.matched_venue = matched_venue
+            event.status = SwipeEvent.Status.COMPLETED
+            event.save(update_fields=["matched_venue", "status", "updated_at"])
+
+            channel_layer = get_channel_layer()
+            if channel_layer:
+                for member in group.memberships.all():
+                    async_to_sync(channel_layer.group_send)(
+                        f"user_notifications_{member.user.id}",
+                        {
+                            "type": "swipe_session_update",
+                            "group_id": str(group.id),
+                        },
+                    )
+
+
 def api_remove_from_group(request, group_id, user_id):
     """
     DELETE /api/groups/<id>/members/<user_id>/
@@ -598,6 +656,11 @@ def api_remove_from_group(request, group_id, user_id):
                 message_type=Message.MessageType.SYSTEM,
                 body=f"{username_display} was removed from the group",
             )
+            from chat.views import notify_chat_users
+
+            notify_chat_users(group.chat)
+
+        check_and_complete_active_swipe_events(group)
 
         return JsonResponse({"success": True, "group": _group_to_json(group)})
 
@@ -718,6 +781,11 @@ def api_leave_group(request, group_id):
                     message_type=Message.MessageType.SYSTEM,
                     body=f"{username_display} left the group",
                 )
+                from chat.views import notify_chat_users
+
+                notify_chat_users(group.chat)
+
+            check_and_complete_active_swipe_events(group)
 
         return JsonResponse({"success": True, "message": "You have left the group"})
 
@@ -1445,6 +1513,9 @@ def api_finish_swiping(request, group_id, event_id):
                     message_type=Message.MessageType.SYSTEM,
                     body=f"{username_display} finished swiping",
                 )
+                from chat.views import notify_chat_users
+
+                notify_chat_users(group.chat)
 
         # Auto-complete the event if all members have finished swiping
         completed_count = event.completed_by.count()
@@ -1475,6 +1546,20 @@ def api_finish_swiping(request, group_id, event_id):
                 event.matched_venue = matched_venue
             event.status = SwipeEvent.Status.COMPLETED
             event.save(update_fields=["matched_venue", "status", "updated_at"])
+
+        from channels.layers import get_channel_layer
+        from asgiref.sync import async_to_sync
+
+        channel_layer = get_channel_layer()
+        if channel_layer:
+            for member in group.memberships.all():
+                async_to_sync(channel_layer.group_send)(
+                    f"user_notifications_{member.user.id}",
+                    {
+                        "type": "swipe_session_update",
+                        "group_id": str(group.id),
+                    },
+                )
 
         return JsonResponse(
             {
@@ -1545,6 +1630,20 @@ def api_reswipe(request, group_id, event_id):
         # Clear exact user swipes and revert completion flag
         Swipe.objects.filter(event=event, user=request.user).delete()
         event.completed_by.remove(request.user)
+
+        from channels.layers import get_channel_layer
+        from asgiref.sync import async_to_sync
+
+        channel_layer = get_channel_layer()
+        if channel_layer:
+            for member in group.memberships.all():
+                async_to_sync(channel_layer.group_send)(
+                    f"user_notifications_{member.user.id}",
+                    {
+                        "type": "swipe_session_update",
+                        "group_id": str(group.id),
+                    },
+                )
 
         return JsonResponse({"success": True})
     except (Group.DoesNotExist, SwipeEvent.DoesNotExist):

--- a/frontend/src/app/contexts/app-context.tsx
+++ b/frontend/src/app/contexts/app-context.tsx
@@ -283,6 +283,41 @@ function AppInner({ children }: { children: ReactNode }) {
     }
   }, []);
 
+  const fetchSwipeEvents = useCallback(async (groupId: string, signal?: AbortSignal) => {
+    try {
+      const res = await fetch(apiUrl(`/api/groups/${groupId}/events/`), {
+        credentials: 'include',
+        signal,
+      });
+      const data = await res.json();
+      if (data.success) {
+        setSwipeEvents(
+          data.events.map((e: {
+            id: number; group_id: number; name: string; status: string;
+            created_at: string; scheduled_for: string | null; matched_venue_id: number | null;
+            total_participants: number; completed_participants_count: number;
+            borough?: string; neighborhood?: string;
+          }) => ({
+            id: String(e.id),
+            groupId: String(e.group_id),
+            name: e.name,
+            status: e.status as SwipeEvent['status'],
+            createdAt: e.created_at,
+            scheduledFor: e.scheduled_for || undefined,
+            matchedRestaurantId: e.matched_venue_id ? String(e.matched_venue_id) : undefined,
+            borough: e.borough || '',
+            neighborhood: e.neighborhood || '',
+            totalParticipants: e.total_participants,
+            completedParticipantsCount: e.completed_participants_count,
+          }))
+        );
+      }
+    } catch (error) {
+      if (error instanceof DOMException && error.name === 'AbortError') return;
+      console.error('Failed to fetch swipe events:', error);
+    }
+  }, []);
+
   const fetchUserChats = useCallback(async () => {
     try {
       const res = await fetch(apiUrl('/api/chat/'), { credentials: 'include' });
@@ -372,6 +407,10 @@ function AppInner({ children }: { children: ReactNode }) {
              fetchUserChats();
           } else if (data.type === 'notification_update') {
              fetchInvitations();
+          } else if (data.type === 'swipe_session_update') {
+             if (data.group_id) {
+               fetchSwipeEvents(String(data.group_id));
+             }
           }
         } catch (e) {
           console.error("Failed to parse websocket message", e);
@@ -397,7 +436,7 @@ function AppInner({ children }: { children: ReactNode }) {
         ws.close();
       }
     };
-  }, [currentUser, fetchUserChats, fetchInvitations]);
+  }, [currentUser, fetchUserChats, fetchInvitations, fetchSwipeEvents]);
 
   // ---------------------------------------------------------------------------
   // Invitations
@@ -804,41 +843,6 @@ function AppInner({ children }: { children: ReactNode }) {
     setSwipeEvents((prev) => [...prev, newEvent]);
     return newEvent;
   };
-
-  const fetchSwipeEvents = useCallback(async (groupId: string, signal?: AbortSignal) => {
-    try {
-      const res = await fetch(apiUrl(`/api/groups/${groupId}/events/`), {
-        credentials: 'include',
-        signal,
-      });
-      const data = await res.json();
-      if (data.success) {
-        setSwipeEvents(
-          data.events.map((e: {
-            id: number; group_id: number; name: string; status: string;
-            created_at: string; scheduled_for: string | null; matched_venue_id: number | null;
-            total_participants: number; completed_participants_count: number;
-            borough?: string; neighborhood?: string;
-          }) => ({
-            id: String(e.id),
-            groupId: String(e.group_id),
-            name: e.name,
-            status: e.status as SwipeEvent['status'],
-            createdAt: e.created_at,
-            scheduledFor: e.scheduled_for || undefined,
-            matchedRestaurantId: e.matched_venue_id ? String(e.matched_venue_id) : undefined,
-            borough: e.borough || '',
-            neighborhood: e.neighborhood || '',
-            totalParticipants: e.total_participants,
-            completedParticipantsCount: e.completed_participants_count,
-          }))
-        );
-      }
-    } catch (error) {
-      if (error instanceof DOMException && error.name === 'AbortError') return;
-      console.error('Failed to fetch swipe events:', error);
-    }
-  }, []);
 
   const addSwipe = async (
     eventId: string,

--- a/frontend/src/app/contexts/app-context.tsx
+++ b/frontend/src/app/contexts/app-context.tsx
@@ -289,6 +289,7 @@ function AppInner({ children }: { children: ReactNode }) {
         credentials: 'include',
         signal,
       });
+      if (!res.ok) return;
       const data = await res.json();
       if (data.success) {
         setSwipeEvents(

--- a/frontend/src/app/pages/swipe-page.tsx
+++ b/frontend/src/app/pages/swipe-page.tsx
@@ -6,7 +6,7 @@ import { RestaurantCard } from "@/app/components/restaurant-card";
 import { ChatSidebar } from "@/app/components/chat-sidebar";
 import { Button } from "@/app/components/ui/button";
 import { Progress } from "@/app/components/ui/progress";
-import { MessageCircle, Users, RotateCcw, Info, Star, Home } from "lucide-react";
+import { MessageCircle, Users, RotateCcw, Info, Star } from "lucide-react";
 import { toast } from "sonner";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/app/components/ui/table";
 import { RestaurantInfoDialog } from "@/app/components/restaurant-info-dialog";
@@ -215,9 +215,9 @@ export function SwipePage() {
               <RotateCcw className="w-4 h-4 mr-2" />
               Reswipe Session
             </Button>
-            <Button onClick={() => navigate("/home")} className="bg-gradient-to-r from-purple-600 to-pink-600 hover:from-purple-700 hover:to-pink-700 text-white font-semibold flex items-center">
-              <Home className="w-4 h-4 mr-2" />
-              Back to Home
+            <Button onClick={() => navigate(`/group/${group.id}`)} className="bg-gradient-to-r from-purple-600 to-pink-600 hover:from-purple-700 hover:to-pink-700 text-white font-semibold flex items-center">
+              <Users className="w-4 h-4 mr-2" />
+              Back to Group
             </Button>
           </div>
         </div>


### PR DESCRIPTION
- Added swipe_session_update broadcast to Daphne consumer and views.
- Wired frontend app-context to automatically fetch swipe session progress on websocket update.
- Updated swipe page to display 'Back to Group' instead of 'Back to Home'.
- Handled member removal edge cases to ensure active swipe sessions calculate matches correctly.