### PR TITLE
Fix duplicate fetched_at migration and WebSocket Valkey timeout

### DIFF
--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -153,6 +153,10 @@ if _redis_url:
             "BACKEND": "channels_valkey.core.ValkeyChannelLayer",
             "CONFIG": {
                 "hosts": [_redis_url],
+                # No socket read timeout — consumers subscribe and wait indefinitely
+                # for messages. A short timeout (valkey default: 5s) causes the
+                # connection to crash while idle, producing a reconnect storm.
+                "socket_timeout": None,
             },
         },
     }

--- a/backend/venues/migrations/0008_venuephoto_fetched_at.py
+++ b/backend/venues/migrations/0008_venuephoto_fetched_at.py
@@ -3,22 +3,20 @@ from django.db import migrations, models
 
 def _add_fetched_at(apps, schema_editor):
     connection = schema_editor.connection
-    with connection.cursor() as cursor:
-        if connection.vendor == "postgresql":
-            cursor.execute(
-                "SELECT 1 FROM information_schema.columns "
-                "WHERE table_name='venues_venuephoto' AND column_name='fetched_at'"
-            )
-            exists = cursor.fetchone() is not None
-        else:
+    if connection.vendor == "postgresql":
+        # IF NOT EXISTS is atomic on PostgreSQL — no check-then-act race.
+        schema_editor.execute(
+            "ALTER TABLE venues_venuephoto ADD COLUMN IF NOT EXISTS fetched_at TIMESTAMPTZ NULL"
+        )
+    else:
+        # SQLite does not support IF NOT EXISTS for ADD COLUMN; check manually.
+        with connection.cursor() as cursor:
             cursor.execute("PRAGMA table_info(venues_venuephoto)")
             exists = any(row[1] == "fetched_at" for row in cursor.fetchall())
-
-    if not exists:
-        schema_editor.execute(
-            "ALTER TABLE venues_venuephoto ADD COLUMN fetched_at %s NULL"
-            % ("TIMESTAMPTZ" if connection.vendor == "postgresql" else "DATETIME")
-        )
+        if not exists:
+            schema_editor.execute(
+                "ALTER TABLE venues_venuephoto ADD COLUMN fetched_at DATETIME NULL"
+            )
 
 
 def _remove_fetched_at(apps, schema_editor):

--- a/backend/venues/migrations/0008_venuephoto_fetched_at.py
+++ b/backend/venues/migrations/0008_venuephoto_fetched_at.py
@@ -28,9 +28,7 @@ def _remove_fetched_at(apps, schema_editor):
             "ALTER TABLE venues_venuephoto DROP COLUMN IF EXISTS fetched_at"
         )
     else:
-        schema_editor.execute(
-            "ALTER TABLE venues_venuephoto DROP COLUMN fetched_at"
-        )
+        schema_editor.execute("ALTER TABLE venues_venuephoto DROP COLUMN fetched_at")
 
 
 class Migration(migrations.Migration):

--- a/backend/venues/migrations/0008_venuephoto_fetched_at.py
+++ b/backend/venues/migrations/0008_venuephoto_fetched_at.py
@@ -1,6 +1,38 @@
 from django.db import migrations, models
 
 
+def _add_fetched_at(apps, schema_editor):
+    connection = schema_editor.connection
+    with connection.cursor() as cursor:
+        if connection.vendor == "postgresql":
+            cursor.execute(
+                "SELECT 1 FROM information_schema.columns "
+                "WHERE table_name='venues_venuephoto' AND column_name='fetched_at'"
+            )
+            exists = cursor.fetchone() is not None
+        else:
+            cursor.execute("PRAGMA table_info(venues_venuephoto)")
+            exists = any(row[1] == "fetched_at" for row in cursor.fetchall())
+
+    if not exists:
+        schema_editor.execute(
+            "ALTER TABLE venues_venuephoto ADD COLUMN fetched_at %s NULL"
+            % ("TIMESTAMPTZ" if connection.vendor == "postgresql" else "DATETIME")
+        )
+
+
+def _remove_fetched_at(apps, schema_editor):
+    connection = schema_editor.connection
+    if connection.vendor == "postgresql":
+        schema_editor.execute(
+            "ALTER TABLE venues_venuephoto DROP COLUMN IF EXISTS fetched_at"
+        )
+    else:
+        schema_editor.execute(
+            "ALTER TABLE venues_venuephoto DROP COLUMN fetched_at"
+        )
+
+
 class Migration(migrations.Migration):
 
     dependencies = [
@@ -8,17 +40,16 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
-        # Use IF NOT EXISTS so this is safe to run on databases that already
-        # had the column added by the old 0006_venuephoto_fetched_at migration.
-        migrations.RunSQL(
-            sql="ALTER TABLE venues_venuephoto ADD COLUMN IF NOT EXISTS fetched_at TIMESTAMPTZ NULL;",
-            reverse_sql="ALTER TABLE venues_venuephoto DROP COLUMN IF EXISTS fetched_at;",
+        migrations.SeparateDatabaseAndState(
             state_operations=[
                 migrations.AddField(
                     model_name="venuephoto",
                     name="fetched_at",
                     field=models.DateTimeField(blank=True, null=True),
                 ),
+            ],
+            database_operations=[
+                migrations.RunPython(_add_fetched_at, _remove_fetched_at),
             ],
         ),
     ]

--- a/backend/venues/migrations/0008_venuephoto_fetched_at.py
+++ b/backend/venues/migrations/0008_venuephoto_fetched_at.py
@@ -8,9 +8,17 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
-        migrations.AddField(
-            model_name="venuephoto",
-            name="fetched_at",
-            field=models.DateTimeField(blank=True, null=True),
+        # Use IF NOT EXISTS so this is safe to run on databases that already
+        # had the column added by the old 0006_venuephoto_fetched_at migration.
+        migrations.RunSQL(
+            sql="ALTER TABLE venues_venuephoto ADD COLUMN IF NOT EXISTS fetched_at TIMESTAMPTZ NULL;",
+            reverse_sql="ALTER TABLE venues_venuephoto DROP COLUMN IF EXISTS fetched_at;",
+            state_operations=[
+                migrations.AddField(
+                    model_name="venuephoto",
+                    name="fetched_at",
+                    field=models.DateTimeField(blank=True, null=True),
+                ),
+            ],
         ),
     ]

--- a/backend/venues/migrations/0008_venuephoto_fetched_at.py
+++ b/backend/venues/migrations/0008_venuephoto_fetched_at.py
@@ -19,16 +19,6 @@ def _add_fetched_at(apps, schema_editor):
             )
 
 
-def _remove_fetched_at(apps, schema_editor):
-    connection = schema_editor.connection
-    if connection.vendor == "postgresql":
-        schema_editor.execute(
-            "ALTER TABLE venues_venuephoto DROP COLUMN IF EXISTS fetched_at"
-        )
-    else:
-        schema_editor.execute("ALTER TABLE venues_venuephoto DROP COLUMN fetched_at")
-
-
 class Migration(migrations.Migration):
 
     dependencies = [
@@ -45,7 +35,10 @@ class Migration(migrations.Migration):
                 ),
             ],
             database_operations=[
-                migrations.RunPython(_add_fetched_at, _remove_fetched_at),
+                # Reverse is a no-op: the column may have pre-existed on production
+                # (added by the legacy 0006 migration). Dropping it on rollback
+                # would cause data loss for databases we didn't create it on.
+                migrations.RunPython(_add_fetched_at, migrations.RunPython.noop),
             ],
         ),
     ]


### PR DESCRIPTION
Migration 0008: use ADD COLUMN IF NOT EXISTS so the migration is safe on production databases that already had fetched_at added by the old 0006_venuephoto_fetched_at migration before the rename. Without this, psycopg2 raises DuplicateColumn and the deploy fails.

Valkey: set socket_timeout=None on the channel layer so WebSocket consumers can subscribe and wait indefinitely for pub/sub messages. The default 5s timeout was causing TimeoutError on idle connections, producing a constant reconnect loop in /ws/notifications/.