### PR TITLE
Hotfix/valkey socket timeout

### DIFF
--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -153,10 +153,6 @@ if _redis_url:
             "BACKEND": "channels_valkey.core.ValkeyChannelLayer",
             "CONFIG": {
                 "hosts": [_redis_url],
-                # No socket read timeout — consumers subscribe and wait indefinitely
-                # for messages. A short timeout (valkey default: 5s) causes the
-                # connection to crash while idle, producing a reconnect storm.
-                "socket_timeout": None,
             },
         },
     }

--- a/frontend/src/app/components/floating-chat.tsx
+++ b/frontend/src/app/components/floating-chat.tsx
@@ -39,8 +39,14 @@ export function FloatingChat() {
   const messagesEndRef = useRef<HTMLDivElement>(null);
 
 
+  const memberByUserId = useMemo(
+    () => new Map(groups.flatMap(g => g.members).map(m => [m.userId, m])),
+    [groups]
+  );
+
   // Build and sort conversation list
   const conversations = useMemo((): Conversation[] => {
+    const currentUserId = String(currentUser?.id);
     const list: Conversation[] = [
       ...groups.map(g => ({
         id: `group-${g.id}`,
@@ -52,9 +58,10 @@ export function FloatingChat() {
         lastMessageTime: chatMessages[g.id]?.slice(-1)[0]?.timestamp
       })),
       ...dmConversations.map(dm => {
-        const otherParticipantId = dm.participants.find(id => id !== String(currentUser?.id));
-        const otherParticipantName = dm.participantNames.find(name => name !== currentUser?.name) || 'Unknown';
-        const otherMember = groups.flatMap(g => g.members).find(m => m.userId === otherParticipantId);
+        const otherIdx = dm.participants.findIndex(id => id !== currentUserId);
+        const otherParticipantId = otherIdx !== -1 ? dm.participants[otherIdx] : undefined;
+        const otherParticipantName = (otherIdx !== -1 ? dm.participantNames[otherIdx] : undefined) || 'Unknown';
+        const otherMember = otherParticipantId ? memberByUserId.get(otherParticipantId) : undefined;
         return {
           id: `dm-${dm.id}`,
           chatId: `dm-${dm.id}`,
@@ -69,7 +76,7 @@ export function FloatingChat() {
     ];
     list.sort((a, b) => (b.lastMessageTime || '0').localeCompare(a.lastMessageTime || '0'));
     return list;
-  }, [groups, dmConversations, chatMessages, currentUser?.id, currentUser?.name]);
+  }, [groups, dmConversations, chatMessages, currentUser?.id, memberByUserId]);
 
   // Derive the active conversation ID: use explicit selection if valid, else fall back to first
   const activeConversationId = useMemo(

--- a/frontend/src/app/components/floating-chat.tsx
+++ b/frontend/src/app/components/floating-chat.tsx
@@ -22,6 +22,7 @@ interface Conversation {
   chatId: string;  // raw backend ID for message/API calls
   type: ConversationType;
   name: string;
+  photoUrl?: string;
   lastMessage?: string;
   lastMessageTime?: string;
   isGroup: boolean;
@@ -51,12 +52,15 @@ export function FloatingChat() {
         lastMessageTime: chatMessages[g.id]?.slice(-1)[0]?.timestamp
       })),
       ...dmConversations.map(dm => {
+        const otherParticipantId = dm.participants.find(id => id !== String(currentUser?.id));
         const otherParticipantName = dm.participantNames.find(name => name !== currentUser?.name) || 'Unknown';
+        const otherMember = groups.flatMap(g => g.members).find(m => m.userId === otherParticipantId);
         return {
           id: `dm-${dm.id}`,
           chatId: `dm-${dm.id}`,
           type: 'dm' as ConversationType,
           name: otherParticipantName,
+          photoUrl: otherMember?.userPhotoUrl,
           isGroup: false,
           lastMessage: chatMessages[`dm-${dm.id}`]?.slice(-1)[0]?.message,
           lastMessageTime: dm.lastMessageTime
@@ -65,7 +69,7 @@ export function FloatingChat() {
     ];
     list.sort((a, b) => (b.lastMessageTime || '0').localeCompare(a.lastMessageTime || '0'));
     return list;
-  }, [groups, dmConversations, chatMessages, currentUser?.name]);
+  }, [groups, dmConversations, chatMessages, currentUser?.id, currentUser?.name]);
 
   // Derive the active conversation ID: use explicit selection if valid, else fall back to first
   const activeConversationId = useMemo(
@@ -264,17 +268,13 @@ export function FloatingChat() {
                       }`}
                     >
                       <div className="flex items-start gap-2">
-                        <div className={`w-10 h-10 rounded-full flex items-center justify-center flex-shrink-0 ${
-                          conversation.isGroup 
-                            ? 'bg-gradient-to-br from-purple-500 to-pink-500' 
-                            : 'bg-gradient-to-br from-purple-400 to-pink-400'
-                        } text-white font-medium`}>
-                          {conversation.isGroup ? (
+                        {conversation.isGroup ? (
+                          <div className="w-10 h-10 rounded-full flex items-center justify-center flex-shrink-0 bg-gradient-to-br from-purple-500 to-pink-500 text-white">
                             <Users className="w-5 h-5" />
-                          ) : (
-                            conversation.name.charAt(0)
-                          )}
-                        </div>
+                          </div>
+                        ) : (
+                          <UserAvatar photoUrl={conversation.photoUrl} name={conversation.name} size={40} className="flex-shrink-0" />
+                        )}
                         <div className="flex-1 min-w-0">
                           <div className="flex items-center justify-between">
                             <p className={`text-sm truncate ${isSelected ? 'font-semibold' : 'font-medium'}`}>
@@ -300,17 +300,13 @@ export function FloatingChat() {
             {/* Header */}
             <div className="px-4 py-3 border-b bg-background flex items-center justify-between">
               <div className="flex items-center gap-2 min-w-0">
-                <div className={`w-8 h-8 rounded-full flex items-center justify-center flex-shrink-0 ${
-                  selectedConversation?.isGroup 
-                    ? 'bg-gradient-to-br from-purple-500 to-pink-500' 
-                    : 'bg-gradient-to-br from-purple-400 to-pink-400'
-                } text-white text-sm font-medium`}>
-                  {selectedConversation?.isGroup ? (
+                {selectedConversation?.isGroup ? (
+                  <div className="w-8 h-8 rounded-full flex items-center justify-center flex-shrink-0 bg-gradient-to-br from-purple-500 to-pink-500 text-white text-sm">
                     <Users className="w-4 h-4" />
-                  ) : (
-                    selectedConversation?.name.charAt(0)
-                  )}
-                </div>
+                  </div>
+                ) : (
+                  <UserAvatar photoUrl={selectedConversation?.photoUrl} name={selectedConversation?.name} size={32} className="flex-shrink-0" />
+                )}
                 <h3 className="font-semibold truncate">{selectedConversation?.name}</h3>
               </div>
               <div className="flex items-center">

--- a/frontend/src/app/pages/admin-users-page.tsx
+++ b/frontend/src/app/pages/admin-users-page.tsx
@@ -217,6 +217,7 @@ export function AdminUsersPage() {
                       <td className="px-4 py-3">
                         <div className="flex items-center gap-3">
                         <UserAvatar
+                          photoUrl={u.photoUrl}
                           name={u.name}
                           email={u.email}
                           role={u.role}


### PR DESCRIPTION
Fix profile photos in admin user list and DM chat, remove invalid Valkey socket_timeout, and fix WebSocket reconnect loop

Changes:

Admin user list: UserAvatar was missing the photoUrl prop — all users showed gradient initials instead of their actual profile photo
DM chat: Conversation list items and the active conversation header used hardcoded gradient divs with the first initial. Now uses UserAvatar with the other participant's photo, looked up from the already-loaded groups.members (no extra API call). Group conversations keep the Users icon to distinguish them from DMs
Valkey socket_timeout: Removed invalid socket_timeout from ValkeyChannelLayer config — it's not an accepted init kwarg and was crashing channel layer initialization, causing HTTP 500 on every WebSocket connect, and also breaking /finish and /reswipe endpoints that send channel layer notifications