### PR TITLE
Remove moderation queue card and duplicate admin notes column

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,6 +53,11 @@ pnpm-debug.log*
 # Local dev artifacts
 cookies.txt
 
+# QA / Playwright test artifacts
+.qa-screenshots/
+.playwright-mcp/
+/*.png
+
 # Claude Code
 CLAUDE.md
 

--- a/frontend/src/app/pages/admin-dashboard-page.tsx
+++ b/frontend/src/app/pages/admin-dashboard-page.tsx
@@ -1,7 +1,7 @@
 import { useNavigate } from 'react-router';
 import { useAdmin } from '@/app/contexts/admin-context';
 import { Card, CardDescription, CardHeader, CardTitle } from '@/app/components/ui/card';
-import { Users, ShieldCheck, Store, UserPlus, Flag } from 'lucide-react';
+import { Users, ShieldCheck, Store, UserPlus } from 'lucide-react';
 
 export function AdminDashboardPage() {
   const { currentAdmin } = useAdmin();
@@ -81,20 +81,6 @@ export function AdminDashboardPage() {
           </CardHeader>
         </Card>
 
-        <Card
-          className="cursor-pointer hover:shadow-lg transition-shadow"
-          onClick={() => navigate('/admin/moderation')}
-        >
-          <CardHeader className="pb-6">
-            <div className="w-12 h-12 bg-red-100 rounded-xl flex items-center justify-center mb-3">
-              <Flag className="w-6 h-6 text-red-600" />
-            </div>
-            <CardTitle className="mb-2">Moderation Queue</CardTitle>
-            <CardDescription>
-              Review flagged reviews and comments
-            </CardDescription>
-          </CardHeader>
-        </Card>
       </div>
     </div>
   );

--- a/frontend/src/app/pages/venue-dashboard-page.tsx
+++ b/frontend/src/app/pages/venue-dashboard-page.tsx
@@ -299,7 +299,6 @@ export function VenueDashboardPage() {
                         <th className="px-6 py-3">Location</th>
                         <th className="px-6 py-3">Date Submitted</th>
                         <th className="px-6 py-3">Status</th>
-                        <th className="px-6 py-3">Admin Notes</th>
                       </tr>
                     </thead>
                     <tbody className="divide-y divide-border">
@@ -351,12 +350,6 @@ export function VenueDashboardPage() {
                                 Reason: {claim.adminNote}
                               </p>
                             )}
-                          </td>
-                          <td
-                            className="px-6 py-4 text-muted-foreground max-w-xs truncate"
-                            title={claim.adminNote || '-'}
-                          >
-                            {claim.adminNote || '-'}
                           </td>
                         </tr>
                       ))}


### PR DESCRIPTION
## Summary
- Removed the **Moderation Queue** card from the admin dashboard quick actions (the underlying `/admin/moderation` page and backend API are unchanged — just the dashboard entry point is gone).
- Removed the standalone **"Admin Notes"** column from the venue manager dashboard claims table. The column duplicated the rejection reason, which is already rendered under the Rejected status badge as `Reason: ...`, so venue managers still see why their claim was rejected.
- Added local QA screenshot / Playwright artifact paths to `.gitignore`.

## Test plan
- [x] Log in as admin → `/admin/dashboard` shows 4 quick action cards (Users, Venue Verification, Venues, Add New Admin); no Moderation Queue card.
- [x] Log in as venue manager → `/venue/dashboard` → select **Rejected claims**; table header shows `Venue | Location | Date Submitted | Status` (no Admin Notes column).
- [x] Reject a claim from `/admin/venue-verification` with a note, then verify the venue manager sees `Reason: <note>` rendered under the Rejected badge in their dashboard.